### PR TITLE
fix(routing): ajout var env APP_ROOT_URL pour fosjsrouting bundle

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,8 @@
 APP_ENV=dev
 APP_SECRET=
 
-# URL publique de l'application (information éditoriale
-# utilisée dans les mentions légales et la gestion des cookies)
-APP_URL="xxx-xxx-xxx.ign.fr"
+# URL publique de l'application
+APP_ROOT_URL=
 
 # URLs de l'API entrepôt
 API_ENTREPOT_URL=https://geoplateforme-gpf-warehouse.qua.gpf-tech.ign.fr/

--- a/assets/router/router.ts
+++ b/assets/router/router.ts
@@ -1,6 +1,7 @@
+import Routing from "fos-router";
 import { createRouter, defineRoute, param } from "type-route";
 
-export const appRoot = (document.getElementById("root") as HTMLDivElement).dataset?.appRoot ?? "";
+export const appRoot = Routing.getBaseUrl(); // (document.getElementById("root") as HTMLDivElement).dataset?.appRoot ?? "";
 
 const routeDefs = {
     // routes non protégées

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -4,7 +4,7 @@ framework:
 
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: "%env(resolve:APP_ROOT_URL)%"
 
 when@prod:
     framework:


### PR DESCRIPTION
On se sert de la version typescript de fosjsrouting bundle. Au moment de yarn dev, donc dans la CLI, il va générer toutes les routes symfony dans un fichier json. Et comme on est dans la CLI, il n'a pas le contexte du navigateur donc il ne peut pas connaître la `base_uri`. On est donc obligé de lui la donner explicitement.