### PR TITLE
ci: divise jobs github actions lint et style en 2

### DIFF
--- a/.github/workflows/code-lint-and-style.yml
+++ b/.github/workflows/code-lint-and-style.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     php:
-        name: PHP - lint & style
+        name: PHP
         runs-on: ubuntu-latest
 
         steps:
@@ -33,13 +33,13 @@ jobs:
               run: composer check-rules
 
     js:
-        name: JavaScript - lint & style
+        name: JavaScript
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
-              
+
             - name: Use Node.js 18.x
               uses: actions/setup-node@v3
               with:


### PR DESCRIPTION
Divise jobs lint & style pour code PHP et JavaScript en 2 comme avant. Ça avait été réuni en un seul job à un moment parce qu'il y a une dépendance entre les 2 jobs et je ne savais pas comment réutiliser le cache d'un job pour un autre. Maintenant, c'est bon, le job JS réutilise le cache de PHP (notamment pour le package jsroutingbundle).