### PR TITLE
Feat/config events

### DIFF
--- a/assets/@types/alert.ts
+++ b/assets/@types/alert.ts
@@ -1,10 +1,8 @@
-import { AlertProps } from "@codegouvfr/react-dsfr/Alert";
-
 export interface INewAlert {
     title: string;
     description?: string;
     link: { url?: string; label?: string };
-    severity: AlertProps["severity"];
+    severity: "info" | "warning" | "alert" | "weather-orange" | "weather-purple" | "weather-red" | "kidnapping" | "cyberattack" | "witness" | "attack";
     details: string;
     date: Date;
     visibility: {

--- a/assets/@types/alert.ts
+++ b/assets/@types/alert.ts
@@ -1,0 +1,20 @@
+import { AlertProps } from "@codegouvfr/react-dsfr/Alert";
+
+export interface INewAlert {
+    title: string;
+    description?: string;
+    link: { url?: string; label?: string };
+    severity: AlertProps["severity"];
+    details: string;
+    date: Date;
+    visibility: {
+        homepage: boolean;
+        contact: boolean;
+        map: boolean;
+        serviceLevel: boolean;
+    };
+}
+
+export interface IAlert extends INewAlert {
+    id: string;
+}

--- a/assets/@types/alert.ts
+++ b/assets/@types/alert.ts
@@ -1,10 +1,11 @@
-export interface INewAlert {
+export interface IApiAlert {
+    id: string;
     title: string;
     description?: string;
     link: { url?: string; label?: string };
-    severity: "info" | "warning" | "alert" | "weather-orange" | "weather-purple" | "weather-red" | "kidnapping" | "cyberattack" | "witness" | "attack";
+    severity: "info" | "warning" | "alert";
     details: string;
-    date: Date;
+    date: string;
     visibility: {
         homepage: boolean;
         contact: boolean;
@@ -13,6 +14,6 @@ export interface INewAlert {
     };
 }
 
-export interface IAlert extends INewAlert {
-    id: string;
+export interface IAlert extends Omit<IApiAlert, "date"> {
+    date: Date;
 }

--- a/assets/App.tsx
+++ b/assets/App.tsx
@@ -7,6 +7,7 @@ import { FC } from "react";
 import ErrorBoundary from "./components/Utils/ErrorBoundary";
 import RouterRenderer from "./router/RouterRenderer";
 import { RouteProvider } from "./router/router";
+import AlertProvider from "./components/Provider/AlertProvider";
 
 const queryClient = new QueryClient();
 
@@ -21,7 +22,9 @@ const App: FC = () => {
 
             <RouteProvider>
                 <ErrorBoundary>
-                    <RouterRenderer />
+                    <AlertProvider>
+                        <RouterRenderer />
+                    </AlertProvider>
                 </ErrorBoundary>
             </RouteProvider>
         </PersistQueryClientProvider>

--- a/assets/components/Input/DatePicker.tsx
+++ b/assets/components/Input/DatePicker.tsx
@@ -2,7 +2,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 import MuiDsfrThemeProvider from "@codegouvfr/react-dsfr/mui";
 import { cx } from "@codegouvfr/react-dsfr/tools/cx";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFnsV3";
-import { DatePicker as MuiDatePicker } from "@mui/x-date-pickers/DatePicker";
+import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatePickerProps } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider/LocalizationProvider";
 import { enGB as enGBLocale, fr as frLocale } from "date-fns/locale";
 import { useId } from "react";
@@ -12,7 +12,7 @@ import { useLang } from "../../i18n/i18n";
 
 const locales = { en: enGBLocale, fr: frLocale };
 
-type DatePickerProps = {
+interface DatePickerProps extends Omit<MuiDatePickerProps<Date, false>, "onChange"> {
     id?: string;
     label: string;
     hintText?: string;
@@ -22,10 +22,10 @@ type DatePickerProps = {
     minDate?: Date;
     onChange?: (value: Date | undefined) => void;
     className?: string;
-};
+}
 
 const DatePicker = (props: DatePickerProps) => {
-    const { id, label, hintText, state, stateRelatedMessage, value, minDate, onChange, className } = props;
+    const { id, label, hintText, state, stateRelatedMessage, value, minDate, onChange, className, ...datePickerProps } = props;
 
     const { lang } = useLang();
 
@@ -45,8 +45,10 @@ const DatePicker = (props: DatePickerProps) => {
                 </label>
                 <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={locales[lang]}>
                     <MuiDatePicker
+                        {...datePickerProps}
                         slotProps={{
-                            field: { clearable: true, onClear: () => onChange?.(undefined) },
+                            ...datePickerProps.slotProps,
+                            field: { ...datePickerProps.slotProps?.field, clearable: true, onClear: () => onChange?.(undefined) },
                         }}
                         sx={{ width: "100%" }}
                         timezone={"UTC"}

--- a/assets/components/Modal/CreateAlert/CreateAlert.tsx
+++ b/assets/components/Modal/CreateAlert/CreateAlert.tsx
@@ -51,7 +51,7 @@ interface CreateAlertProps {
 
 const CreateAlert: FC<CreateAlertProps> = (props) => {
     const { alert, isEdit, ModalComponent, onSubmit } = props;
-    const { t } = useTranslation("ConfigAlerts");
+    const { t } = useTranslation("alerts");
 
     const methods = useForm({
         mode: "onSubmit",

--- a/assets/components/Modal/CreateAlert/CreateAlert.tsx
+++ b/assets/components/Modal/CreateAlert/CreateAlert.tsx
@@ -1,0 +1,239 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FC, useMemo } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+import { symToStr } from "tsafe/symToStr";
+import * as yup from "yup";
+import { fr } from "@codegouvfr/react-dsfr";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { Select } from "@codegouvfr/react-dsfr/SelectNext";
+import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
+import isURL from "validator/lib/isURL";
+
+import { useTranslation } from "../../../i18n";
+import { INewAlert } from "../../../@types/alert";
+import DatePicker from "../../Input/DatePicker";
+
+import PreviewAlert from "./PreviewAlert";
+import { ModalProps } from "@codegouvfr/react-dsfr/Modal";
+
+const schema = yup.object({
+    title: yup.string().required("Titre requis"),
+    description: yup.string(),
+    link: yup.object({
+        label: yup.string(),
+        url: yup.string().test("check-url", "La chaîne doit être une url valide", (value) => value === "" || isURL(value)),
+    }),
+    severity: yup.string().oneOf(["info", "warning", "error"]).required("Sévérité requise"),
+    details: yup.string().required("Détails requis"),
+    date: yup.date().required("Date requise"),
+    visibility: yup.object({
+        homepage: yup.boolean().required(),
+        contact: yup.boolean().required(),
+        map: yup.boolean().required(),
+        serviceLevel: yup.boolean().required(),
+    }),
+});
+
+const defaultAlert = {
+    title: "",
+    description: "",
+    link: { url: "", label: "" },
+    severity: "info" as const,
+    details: "",
+    date: new Date(),
+    visibility: {
+        homepage: false,
+        contact: false,
+        map: false,
+        serviceLevel: false,
+    },
+};
+
+const severityOptions = [
+    { value: "info", label: "info" },
+    { value: "warning", label: "warning" },
+    { value: "error", label: "error" },
+];
+
+interface CreateAlertProps {
+    ModalComponent: (props: ModalProps) => JSX.Element;
+    onSubmit: (alert: INewAlert) => void;
+}
+
+const CreateAlert: FC<CreateAlertProps> = (props) => {
+    const { ModalComponent, onSubmit } = props;
+    const { t } = useTranslation("ConfigAlerts");
+
+    const date = useMemo(() => new Date(), []);
+    const methods = useForm({
+        mode: "onSubmit",
+        defaultValues: { ...defaultAlert, date },
+        resolver: yupResolver(schema),
+    });
+    const {
+        control,
+        formState: { errors },
+        handleSubmit,
+        register,
+    } = methods;
+
+    const addAlert = handleSubmit((values) => {
+        onSubmit(values);
+    });
+
+    return (
+        <ModalComponent
+            title={t("create_alert")}
+            size="large"
+            buttons={[
+                {
+                    doClosesModal: true,
+                    children: t("modal.cancel"),
+                },
+                {
+                    doClosesModal: false,
+                    children: t("modal.add"),
+                    onClick: addAlert,
+                },
+            ]}
+        >
+            <FormProvider {...methods}>
+                <form onSubmit={addAlert}>
+                    <PreviewAlert />
+                    <Input
+                        label={t("alert.title")}
+                        nativeInputProps={{
+                            ...register("title"),
+                        }}
+                        state={errors.title ? "error" : "default"}
+                        stateRelatedMessage={errors?.title?.message?.toString()}
+                    />
+                    <Input
+                        label={t("alert.description")}
+                        nativeInputProps={{
+                            ...register("description"),
+                        }}
+                        state={errors.description ? "error" : "default"}
+                        stateRelatedMessage={errors?.description?.message?.toString()}
+                    />
+                    <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <Input
+                                label={t("alert.linkLabel")}
+                                nativeInputProps={{
+                                    ...register("link.label"),
+                                }}
+                                state={errors.link?.label ? "error" : "default"}
+                                stateRelatedMessage={errors?.link?.label?.message?.toString()}
+                            />
+                        </div>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <Input
+                                label={t("alert.linkUrl")}
+                                nativeInputProps={{
+                                    ...register("link.url"),
+                                }}
+                                state={errors.link?.url ? "error" : "default"}
+                                stateRelatedMessage={errors?.link?.url?.message?.toString()}
+                            />
+                        </div>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <Select
+                                label={t("alert.severity")}
+                                nativeSelectProps={{
+                                    ...register("severity"),
+                                }}
+                                options={severityOptions}
+                                placeholder="Select an option"
+                                state={errors.severity ? "error" : "default"}
+                                stateRelatedMessage={errors?.severity?.message?.toString()}
+                            />
+                        </div>
+                        <Controller
+                            control={control}
+                            name="date"
+                            render={({ field: { onChange, value } }) => (
+                                <DatePicker
+                                    label={t("alert.date")}
+                                    value={value}
+                                    minDate={date}
+                                    onChange={onChange}
+                                    state={errors.date ? "error" : "default"}
+                                    stateRelatedMessage={errors.date?.message?.toString()}
+                                    className={fr.cx("fr-col-12", "fr-col-sm-6")}
+                                    // @ts-expect-error ignore
+                                    slotProps={{ field: { variant: "filled" } }}
+                                />
+                            )}
+                        />
+                    </div>
+                    <Input
+                        label={t("alert.details")}
+                        nativeInputProps={{
+                            ...register("details"),
+                        }}
+                        state={errors.details ? "error" : "default"}
+                        stateRelatedMessage={errors?.details?.message?.toString()}
+                    />
+                    <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <div className={fr.cx("fr-input-group")}>
+                                <Controller
+                                    control={control}
+                                    name="visibility.homepage"
+                                    render={({ field: { onChange, value } }) => (
+                                        <ToggleSwitch inputTitle={t("alert.homepage")} label={t("alert.homepage")} onChange={onChange} checked={value} />
+                                    )}
+                                />
+                            </div>
+                        </div>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <div className={fr.cx("fr-input-group")}>
+                                <Controller
+                                    control={control}
+                                    name="visibility.contact"
+                                    render={({ field: { onChange, value } }) => (
+                                        <ToggleSwitch inputTitle={t("alert.contact")} label={t("alert.contact")} onChange={onChange} checked={value} />
+                                    )}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                    <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <div className={fr.cx("fr-input-group")}>
+                                <Controller
+                                    control={control}
+                                    name="visibility.map"
+                                    render={({ field: { onChange, value } }) => (
+                                        <ToggleSwitch inputTitle={t("alert.map")} label={t("alert.map")} onChange={onChange} checked={value} />
+                                    )}
+                                />
+                            </div>
+                        </div>
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <div className={fr.cx("fr-input-group")}>
+                                <Controller
+                                    control={control}
+                                    name="visibility.serviceLevel"
+                                    render={({ field: { onChange, value } }) => (
+                                        <ToggleSwitch
+                                            inputTitle={t("alert.serviceLevel")}
+                                            label={t("alert.serviceLevel")}
+                                            onChange={onChange}
+                                            checked={value}
+                                        />
+                                    )}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                    <input type="submit" hidden />
+                </form>
+            </FormProvider>
+        </ModalComponent>
+    );
+};
+CreateAlert.displayName = symToStr({ CreateAlert });
+
+export default CreateAlert;

--- a/assets/components/Modal/CreateAlert/CreateAlert.tsx
+++ b/assets/components/Modal/CreateAlert/CreateAlert.tsx
@@ -11,10 +11,10 @@ import isURL from "validator/lib/isURL";
 
 import { useTranslation } from "../../../i18n";
 import { IAlert } from "../../../@types/alert";
-import DatePicker from "../../Input/DatePicker";
 
 import PreviewAlert from "./PreviewAlert";
 import { ModalProps } from "@codegouvfr/react-dsfr/Modal";
+import { formatDateTimeLocal } from "../../../utils";
 
 const date = new Date();
 export const alertSchema = yup.object({
@@ -25,10 +25,7 @@ export const alertSchema = yup.object({
         label: yup.string(),
         url: yup.string().test("check-url", "La chaîne doit être une url valide", (value) => value === "" || isURL(value)),
     }),
-    severity: yup
-        .string()
-        .oneOf(["info", "warning", "alert", "weather-orange", "weather-purple", "weather-red", "kidnapping", "cyberattack", "witness", "attack"])
-        .required("Sévérité requise"),
+    severity: yup.string().oneOf(["info", "warning", "alert"]).required("Sévérité requise"),
     details: yup.string().required("Détails requis"),
     date: yup.date().required("Date requise"),
     visibility: yup.object({
@@ -42,7 +39,7 @@ export const alertSchema = yup.object({
 const severityOptions = [
     { value: "info", label: "info" },
     { value: "warning", label: "warning" },
-    { value: "error", label: "error" },
+    { value: "alert", label: "alert" },
 ];
 
 interface CreateAlertProps {
@@ -145,25 +142,28 @@ const CreateAlert: FC<CreateAlertProps> = (props) => {
                                 stateRelatedMessage={errors?.severity?.message?.toString()}
                             />
                         </div>
-                        <Controller
-                            control={control}
-                            name="date"
-                            render={({ field: { onChange, value } }) => (
-                                <DatePicker
-                                    label={t("alert.date")}
-                                    value={value}
-                                    minDate={date}
-                                    onChange={onChange}
-                                    state={errors.date ? "error" : "default"}
-                                    stateRelatedMessage={errors.date?.message?.toString()}
-                                    className={fr.cx("fr-col-12", "fr-col-sm-6")}
-                                    // @ts-expect-error ignore
-                                    slotProps={{ field: { variant: "filled" } }}
-                                />
-                            )}
-                        />
+                        <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
+                            <Controller
+                                control={control}
+                                name="date"
+                                render={({ field: { onChange, value } }) => (
+                                    <Input
+                                        label={t("alert.date")}
+                                        nativeInputProps={{
+                                            value: formatDateTimeLocal(value),
+                                            min: formatDateTimeLocal(date),
+                                            type: "datetime-local",
+                                            onChange,
+                                        }}
+                                        state={errors.date ? "error" : "default"}
+                                        stateRelatedMessage={errors.date?.message?.toString()}
+                                    />
+                                )}
+                            />
+                        </div>
                     </div>
                     <Input
+                        className="fr-mt-3w"
                         label={t("alert.details")}
                         nativeInputProps={{
                             ...register("details"),

--- a/assets/components/Modal/CreateAlert/PreviewAlert.tsx
+++ b/assets/components/Modal/CreateAlert/PreviewAlert.tsx
@@ -1,0 +1,41 @@
+import { FC } from "react";
+import { symToStr } from "tsafe/symToStr";
+import { Notice } from "@codegouvfr/react-dsfr/Notice";
+import { useWatch } from "react-hook-form";
+import { fr } from "@codegouvfr/react-dsfr";
+
+import { useTranslation } from "../../../i18n";
+
+const PreviewAlert: FC = () => {
+    const { t } = useTranslation("ConfigAlerts");
+    const form = useWatch();
+    const title = (
+        <>
+            {form.title} {form.description}
+            {form.link.label && (
+                <>
+                    {" "}
+                    <a
+                        className={fr.cx("fr-notice__link")}
+                        href={form.link.url}
+                        target="_blank"
+                        rel="noreferrer external"
+                        title={`${form.link.label} - ${t("newWindow")}`}
+                    >
+                        {form.link.label}
+                    </a>
+                </>
+            )}
+        </>
+    );
+
+    return (
+        <div className={fr.cx("fr-input-group")}>
+            <span className={fr.cx("fr-label")}>{t("preview")}</span>
+            <Notice className={fr.cx("fr-mt-1w")} isClosable={false} title={title} />
+        </div>
+    );
+};
+PreviewAlert.displayName = symToStr({ PreviewAlert });
+
+export default PreviewAlert;

--- a/assets/components/Modal/CreateAlert/PreviewAlert.tsx
+++ b/assets/components/Modal/CreateAlert/PreviewAlert.tsx
@@ -5,34 +5,18 @@ import { useWatch } from "react-hook-form";
 import { fr } from "@codegouvfr/react-dsfr";
 
 import { useTranslation } from "../../../i18n";
+import { useAlert } from "../../../hooks/useAlert";
+import { IAlert } from "../../../@types/alert";
 
 const PreviewAlert: FC = () => {
-    const { t } = useTranslation("ConfigAlerts");
+    const { t } = useTranslation("alerts");
     const form = useWatch();
-    const title = (
-        <>
-            {form.title} {form.description}
-            {form.link.label && (
-                <>
-                    {" "}
-                    <a
-                        className={fr.cx("fr-notice__link")}
-                        href={form.link.url}
-                        target="_blank"
-                        rel="noreferrer external"
-                        title={`${form.link.label} - ${t("newWindow")}`}
-                    >
-                        {form.link.label}
-                    </a>
-                </>
-            )}
-        </>
-    );
+    const alertProps = useAlert(form as IAlert);
 
     return (
         <div className={fr.cx("fr-input-group")}>
             <span className={fr.cx("fr-label")}>{t("preview")}</span>
-            <Notice className={fr.cx("fr-mt-1w")} isClosable={false} title={title} />
+            {alertProps && <Notice className={fr.cx("fr-mt-1w")} {...alertProps} isClosable={false} />}
         </div>
     );
 };

--- a/assets/components/Provider/AlertProvider.tsx
+++ b/assets/components/Provider/AlertProvider.tsx
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { FC, PropsWithChildren, useEffect } from "react";
+import { symToStr } from "tsafe/symToStr";
+
+import { IApiAlert } from "../../@types/alert";
+import { CartesApiException } from "../../modules/jsonFetch";
+import RQKeys from "../../modules/entrepot/RQKeys";
+import api from "../../entrepot/api";
+import { useAlertStore } from "../../stores/AlertStore";
+
+const AlertProvider: FC<PropsWithChildren> = (props) => {
+    const { children } = props;
+    const setAlerts = useAlertStore((state) => state.setAlerts);
+
+    const { data } = useQuery<IApiAlert[], CartesApiException>({
+        queryKey: RQKeys.alerts(),
+        queryFn: ({ signal }) => api.alerts.get({ signal, cache: "no-store" }),
+    });
+
+    useEffect(() => {
+        if (data) {
+            setAlerts(data.map((rawAlert) => ({ ...rawAlert, date: new Date(rawAlert.date) })));
+        }
+    }, [data, setAlerts]);
+
+    return children;
+};
+AlertProvider.displayName = symToStr({ AlertProvider });
+
+export default AlertProvider;

--- a/assets/entrepot/api/alerts.ts
+++ b/assets/entrepot/api/alerts.ts
@@ -1,0 +1,20 @@
+import { IApiAlert } from "../../@types/alert";
+import { jsonFetch } from "../../modules/jsonFetch";
+
+const datastoreId = "5cb4fdb0-6f6c-4422-893d-e04564bfcc10";
+const annexePath = "/public/alerts.json";
+const fileName = annexePath.substring(annexePath.lastIndexOf("/") + 1);
+const baseUrl = "https://data.geopf.fr/annexes/cartes.gouv.fr-config";
+
+const get = (otherOptions: RequestInit = {}) => {
+    return jsonFetch<IApiAlert[]>(`${baseUrl}${annexePath}`, {
+        ...otherOptions,
+    });
+};
+
+export default {
+    annexePath,
+    datastoreId,
+    fileName,
+    get,
+};

--- a/assets/entrepot/api/annexe.ts
+++ b/assets/entrepot/api/annexe.ts
@@ -19,7 +19,7 @@ const replaceFile = (datastoreId: string, annexeId: string, file: File) => {
     formData.append("file", file);
 
     const url = SymfonyRouting.generate("cartesgouvfr_api_annexe_replace_file", { datastoreId, annexeId });
-    return jsonFetch<Annexe>(url, { method: "PUT" }, formData, true, true);
+    return jsonFetch<Annexe>(url, { method: "POST" }, formData, true, true);
 };
 
 const addThumbnail = (datastoreId: string, data: object) => {

--- a/assets/entrepot/api/index.ts
+++ b/assets/entrepot/api/index.ts
@@ -18,6 +18,7 @@ import style from "./style";
 import metadata from "./metadata";
 import statics from "./statics";
 import geonetwork from "./geonetwork";
+import alerts from "./alerts";
 
 const api = {
     contact,
@@ -39,6 +40,7 @@ const api = {
     style,
     metadata,
     statics,
+    alerts,
     // epsg.io
     epsg,
     geonetwork,

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -7,6 +7,7 @@ const { i18n } = declareComponentKeys<
     | "edit_alert"
     | "alerts_updated"
     | "alerts_update_error"
+    | "alerts_unsaved"
     | "save"
     | "table_caption"
     | "title"
@@ -37,6 +38,7 @@ export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     edit_alert: "Modifier une alerte",
     alerts_updated: "Alertes mises à jour",
     alerts_update_error: "Erreur lors de la mise à jour des alertes",
+    alerts_unsaved: "Vous avez des modifications non enregistrées",
     save: "Enregistrer",
     table_caption: "Alertes",
     title: "Configuration : Alertes",
@@ -66,6 +68,7 @@ export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
     edit_alert: undefined,
     alerts_updated: undefined,
     alerts_update_error: undefined,
+    alerts_unsaved: undefined,
     save: undefined,
     table_caption: undefined,
     title: undefined,

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -30,10 +30,10 @@ const { i18n } = declareComponentKeys<
     | "modal.cancel"
     | "modal.add"
     | "modal.edit"
->()("ConfigAlerts");
+>()("alerts");
 export type I18n = typeof i18n;
 
-export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
+export const AlertsFrTranslations: Translations<"fr">["alerts"] = {
     create_alert: "Créer une alerte",
     edit_alert: "Modifier une alerte",
     alerts_updated: "Alertes mises à jour",
@@ -63,7 +63,7 @@ export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     "modal.edit": "Modifier",
 };
 
-export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
+export const AlertsEnTranslations: Translations<"en">["alerts"] = {
     create_alert: undefined,
     edit_alert: undefined,
     alerts_updated: undefined,

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -4,43 +4,76 @@ import { Translations } from "../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
     | "create_alert"
-    | "enregistrer"
+    | "save"
     | "table_caption"
     | "title"
-    | "th.severity"
-    | "th.title"
-    | "th.date"
-    | "th.homepage"
-    | "th.contact"
-    | "th.map"
-    | "th.serviceLevel"
+    | "preview"
+    | "newWindow"
+    | "actions"
+    | "update"
+    | "delete"
+    | "alert.severity"
+    | "alert.title"
+    | "alert.description"
+    | "alert.linkUrl"
+    | "alert.linkLabel"
+    | "alert.date"
+    | "alert.details"
+    | "alert.homepage"
+    | "alert.contact"
+    | "alert.map"
+    | "alert.serviceLevel"
+    | "modal.cancel"
+    | "modal.add"
 >()("ConfigAlerts");
 export type I18n = typeof i18n;
 
 export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     create_alert: "Créer une alerte",
-    enregistrer: "Enregistrer",
+    save: "Enregistrer",
     table_caption: "Alertes",
     title: "configuration : Alerte",
-    "th.severity": "Sévérité",
-    "th.title": "Titre",
-    "th.date": "Date",
-    "th.homepage": "Visible sur la page d'accueil",
-    "th.contact": "Visible sur la page de contact",
-    "th.map": "Visible sur la carte",
-    "th.serviceLevel": "Visible sur la page niveau de service",
+    preview: "Prévisualisation",
+    newWindow: "nouvelle fenêtre",
+    actions: "Actions",
+    update: "Modifier",
+    delete: "Supprimer",
+    "alert.title": "Titre",
+    "alert.description": "Description",
+    "alert.linkUrl": "URL du lien",
+    "alert.linkLabel": "Label du lien",
+    "alert.severity": "Sévérité",
+    "alert.date": "Date",
+    "alert.details": "Détails",
+    "alert.homepage": "Visible sur la page d'accueil",
+    "alert.contact": "Visible sur la page de contact",
+    "alert.map": "Visible sur la carte",
+    "alert.serviceLevel": "Visible sur la page niveau de service",
+    "modal.cancel": "Annuler",
+    "modal.add": "Ajouter",
 };
 
 export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
     create_alert: undefined,
-    enregistrer: undefined,
+    save: undefined,
     table_caption: undefined,
     title: undefined,
-    "th.severity": undefined,
-    "th.title": undefined,
-    "th.date": undefined,
-    "th.homepage": undefined,
-    "th.contact": undefined,
-    "th.map": undefined,
-    "th.serviceLevel": undefined,
+    preview: undefined,
+    newWindow: undefined,
+    actions: undefined,
+    update: undefined,
+    delete: undefined,
+    "alert.title": undefined,
+    "alert.description": undefined,
+    "alert.linkUrl": undefined,
+    "alert.linkLabel": undefined,
+    "alert.severity": undefined,
+    "alert.date": undefined,
+    "alert.details": undefined,
+    "alert.homepage": undefined,
+    "alert.contact": undefined,
+    "alert.map": undefined,
+    "alert.serviceLevel": undefined,
+    "modal.cancel": undefined,
+    "modal.add": undefined,
 };

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -4,6 +4,7 @@ import { Translations } from "../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
     | "create_alert"
+    | "edit_alert"
     | "save"
     | "table_caption"
     | "title"
@@ -25,11 +26,13 @@ const { i18n } = declareComponentKeys<
     | "alert.serviceLevel"
     | "modal.cancel"
     | "modal.add"
+    | "modal.edit"
 >()("ConfigAlerts");
 export type I18n = typeof i18n;
 
 export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     create_alert: "Créer une alerte",
+    edit_alert: "Modifier une alerte",
     save: "Enregistrer",
     table_caption: "Alertes",
     title: "configuration : Alerte",
@@ -51,10 +54,12 @@ export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     "alert.serviceLevel": "Visible sur la page niveau de service",
     "modal.cancel": "Annuler",
     "modal.add": "Ajouter",
+    "modal.edit": "Modifier",
 };
 
 export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
     create_alert: undefined,
+    edit_alert: undefined,
     save: undefined,
     table_caption: undefined,
     title: undefined,
@@ -76,4 +81,5 @@ export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
     "alert.serviceLevel": undefined,
     "modal.cancel": undefined,
     "modal.add": undefined,
+    "modal.edit": undefined,
 };

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -10,6 +10,7 @@ const { i18n } = declareComponentKeys<
     | "alerts_unsaved"
     | "save"
     | "table_caption"
+    | "no_alerts"
     | "title"
     | "preview"
     | "newWindow"
@@ -23,6 +24,7 @@ const { i18n } = declareComponentKeys<
     | "alert.linkLabel"
     | "alert.date"
     | "alert.details"
+    | "alert.visible"
     | "alert.homepage"
     | "alert.contact"
     | "alert.map"
@@ -41,6 +43,7 @@ export const AlertsFrTranslations: Translations<"fr">["alerts"] = {
     alerts_unsaved: "Vous avez des modifications non enregistrées",
     save: "Enregistrer",
     table_caption: "Alertes",
+    no_alerts: "Aucune alerte disponible",
     title: "Configuration : Alertes",
     preview: "Prévisualisation",
     newWindow: "nouvelle fenêtre",
@@ -54,10 +57,11 @@ export const AlertsFrTranslations: Translations<"fr">["alerts"] = {
     "alert.severity": "Sévérité",
     "alert.date": "Date",
     "alert.details": "Détails",
-    "alert.homepage": "Visible sur la page d'accueil",
-    "alert.contact": "Visible sur la page de contact",
-    "alert.map": "Visible sur la carte",
-    "alert.serviceLevel": "Visible sur la page niveau de service",
+    "alert.visible": "Visible sur",
+    "alert.homepage": "la page d'accueil",
+    "alert.contact": "la page de contact",
+    "alert.map": "la carte",
+    "alert.serviceLevel": "la page niveau de service",
     "modal.cancel": "Annuler",
     "modal.add": "Ajouter",
     "modal.edit": "Modifier",
@@ -71,6 +75,7 @@ export const AlertsEnTranslations: Translations<"en">["alerts"] = {
     alerts_unsaved: undefined,
     save: undefined,
     table_caption: undefined,
+    no_alerts: undefined,
     title: undefined,
     preview: undefined,
     newWindow: undefined,
@@ -84,6 +89,7 @@ export const AlertsEnTranslations: Translations<"en">["alerts"] = {
     "alert.severity": undefined,
     "alert.date": undefined,
     "alert.details": undefined,
+    "alert.visible": undefined,
     "alert.homepage": undefined,
     "alert.contact": undefined,
     "alert.map": undefined,

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -5,6 +5,8 @@ import { Translations } from "../../../i18n/types";
 const { i18n } = declareComponentKeys<
     | "create_alert"
     | "edit_alert"
+    | "alerts_updated"
+    | "alerts_update_error"
     | "save"
     | "table_caption"
     | "title"
@@ -33,9 +35,11 @@ export type I18n = typeof i18n;
 export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
     create_alert: "Créer une alerte",
     edit_alert: "Modifier une alerte",
+    alerts_updated: "Alertes mises à jour",
+    alerts_update_error: "Erreur lors de la mise à jour des alertes",
     save: "Enregistrer",
     table_caption: "Alertes",
-    title: "configuration : Alerte",
+    title: "Configuration : Alertes",
     preview: "Prévisualisation",
     newWindow: "nouvelle fenêtre",
     actions: "Actions",
@@ -60,6 +64,8 @@ export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
 export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
     create_alert: undefined,
     edit_alert: undefined,
+    alerts_updated: undefined,
+    alerts_update_error: undefined,
     save: undefined,
     table_caption: undefined,
     title: undefined,

--- a/assets/entrepot/pages/config/Alerts.locale.tsx
+++ b/assets/entrepot/pages/config/Alerts.locale.tsx
@@ -1,0 +1,46 @@
+import { declareComponentKeys } from "i18nifty";
+
+import { Translations } from "../../../i18n/types";
+
+const { i18n } = declareComponentKeys<
+    | "create_alert"
+    | "enregistrer"
+    | "table_caption"
+    | "title"
+    | "th.severity"
+    | "th.title"
+    | "th.date"
+    | "th.homepage"
+    | "th.contact"
+    | "th.map"
+    | "th.serviceLevel"
+>()("ConfigAlerts");
+export type I18n = typeof i18n;
+
+export const AlertsFrTranslations: Translations<"fr">["ConfigAlerts"] = {
+    create_alert: "Créer une alerte",
+    enregistrer: "Enregistrer",
+    table_caption: "Alertes",
+    title: "configuration : Alerte",
+    "th.severity": "Sévérité",
+    "th.title": "Titre",
+    "th.date": "Date",
+    "th.homepage": "Visible sur la page d'accueil",
+    "th.contact": "Visible sur la page de contact",
+    "th.map": "Visible sur la carte",
+    "th.serviceLevel": "Visible sur la page niveau de service",
+};
+
+export const AlertsEnTranslations: Translations<"en">["ConfigAlerts"] = {
+    create_alert: undefined,
+    enregistrer: undefined,
+    table_caption: undefined,
+    title: undefined,
+    "th.severity": undefined,
+    "th.title": undefined,
+    "th.date": undefined,
+    "th.homepage": undefined,
+    "th.contact": undefined,
+    "th.map": undefined,
+    "th.serviceLevel": undefined,
+};

--- a/assets/entrepot/pages/config/Alerts.scss
+++ b/assets/entrepot/pages/config/Alerts.scss
@@ -12,6 +12,10 @@
     justify-content: space-between;
 }
 
+.alerts__caption h1 {
+    margin: 0;
+}
+
 .alerts__icon--info {
     color: var(--text-default-info);
 }

--- a/assets/entrepot/pages/config/Alerts.scss
+++ b/assets/entrepot/pages/config/Alerts.scss
@@ -1,9 +1,5 @@
-.alerts__table caption {
-    width: 100%;
-}
-
-.alerts__table td {
-    white-space: nowrap;
+.alerts__table thead tr:first-child th {
+    background-image: none;
 }
 
 .alerts__caption {

--- a/assets/entrepot/pages/config/Alerts.scss
+++ b/assets/entrepot/pages/config/Alerts.scss
@@ -2,6 +2,10 @@
     width: 100%;
 }
 
+.alerts__table td {
+    white-space: nowrap;
+}
+
 .alerts__caption {
     display: flex;
     align-items: center;

--- a/assets/entrepot/pages/config/Alerts.scss
+++ b/assets/entrepot/pages/config/Alerts.scss
@@ -1,0 +1,25 @@
+.alerts__table caption {
+    width: 100%;
+}
+
+.alerts__caption {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.alerts__icon--info {
+    color: var(--text-default-info);
+}
+
+.alerts__icon--warning {
+    color: var(--text-default-warning);
+}
+
+.alerts__icon--error {
+    color: var(--text-default-error);
+}
+
+.alerts__icon--success {
+    color: var(--text-default-success);
+}

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -175,6 +175,7 @@ const Alerts: FC = () => {
             if (index !== -1) {
                 alerts.splice(index, 1);
                 setValue("alerts", alerts);
+                setNotification({ severity: "warning", title: t("alerts_unsaved") });
             }
         };
     }
@@ -192,78 +193,103 @@ const Alerts: FC = () => {
                 <Controller
                     control={control}
                     name="alerts"
-                    render={({ field: { value: alerts } }) => {
-                        if (!alerts) {
-                            return <></>;
-                        }
-                        return (
-                            <Table
-                                className="alerts__table"
-                                caption={t("table_caption")}
-                                noCaption
-                                data={alerts.map((alert, i) => [
-                                    getIcon(alert.severity),
-                                    alert.title,
-                                    formatDateTime(alert.date),
-                                    <ToggleSwitch
-                                        key="switch-homepage"
-                                        inputTitle={t("alert.homepage")}
-                                        label=""
-                                        onChange={handleChange(i, "homepage")}
-                                        checked={alert.visibility.homepage}
-                                    />,
-                                    <ToggleSwitch
-                                        key="switch-contact"
-                                        inputTitle={t("alert.contact")}
-                                        label=""
-                                        onChange={handleChange(i, "contact")}
-                                        checked={alert.visibility.contact}
-                                    />,
-                                    <ToggleSwitch
-                                        key="switch-map"
-                                        inputTitle={t("alert.map")}
-                                        label=""
-                                        onChange={handleChange(i, "map")}
-                                        checked={alert.visibility.map}
-                                    />,
-                                    <ToggleSwitch
-                                        key="switch-serviceLevel"
-                                        inputTitle={t("alert.serviceLevel")}
-                                        label=""
-                                        onChange={handleChange(i, "serviceLevel")}
-                                        checked={alert.visibility.serviceLevel}
-                                    />,
-                                    <div key="actions">
-                                        <Button
-                                            iconId="fr-icon-pencil-line"
-                                            priority="tertiary no outline"
-                                            title={t("update")}
-                                            type="button"
-                                            className={fr.cx("fr-mr-2v")}
-                                            onClick={openUpdateAlert(alert)}
-                                        />
-                                        <Button
-                                            iconId="fr-icon-delete-line"
-                                            priority="tertiary no outline"
-                                            title={t("delete")}
-                                            type="button"
-                                            onClick={deleteAlert(alert)}
-                                        />
-                                    </div>,
-                                ])}
-                                headers={[
-                                    t("alert.severity"),
-                                    t("alert.title"),
-                                    t("alert.date"),
-                                    t("alert.homepage"),
-                                    t("alert.contact"),
-                                    t("alert.map"),
-                                    t("alert.serviceLevel"),
-                                    t("actions"),
-                                ]}
-                            />
-                        );
-                    }}
+                    render={({ field: { value: alerts } }) => (
+                        <div className={fr.cx("fr-table", "fr-table--no-caption")}>
+                            <div className={fr.cx("fr-table__wrapper")}>
+                                <div className={fr.cx("fr-table__container")}>
+                                    <div className={fr.cx("fr-table__content")}>
+                                        <table className="alerts__table">
+                                            <caption>{t("table_caption")}</caption>
+                                            <thead>
+                                                <tr>
+                                                    <th />
+                                                    <th />
+                                                    <th />
+                                                    <th colSpan={4}>{t("alert.visible")}</th>
+                                                    <th />
+                                                </tr>
+                                                <tr>
+                                                    <th>{t("alert.severity")}</th>
+                                                    <th>{t("alert.title")}</th>
+                                                    <th>{t("alert.date")}</th>
+                                                    <th>{t("alert.homepage")}</th>
+                                                    <th>{t("alert.contact")}</th>
+                                                    <th>{t("alert.map")}</th>
+                                                    <th>{t("alert.serviceLevel")}</th>
+                                                    <th>{t("actions")}</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {(!alerts || alerts.length === 0) && (
+                                                    <tr>
+                                                        <td colSpan={8}>{t("no_alerts")}</td>
+                                                    </tr>
+                                                )}
+                                                {alerts?.map((alert, i) => (
+                                                    <tr key={i} data-row-key={i + 1}>
+                                                        <td>{getIcon(alert.severity)}</td>
+                                                        <td>{alert.title}</td>
+                                                        <td>{formatDateTime(alert.date)}</td>
+                                                        <td>
+                                                            <ToggleSwitch
+                                                                inputTitle={t("alert.homepage")}
+                                                                label=""
+                                                                onChange={handleChange(i, "homepage")}
+                                                                checked={alert.visibility.homepage}
+                                                            />
+                                                        </td>
+                                                        <td>
+                                                            <ToggleSwitch
+                                                                inputTitle={t("alert.contact")}
+                                                                label=""
+                                                                onChange={handleChange(i, "contact")}
+                                                                checked={alert.visibility.contact}
+                                                            />
+                                                        </td>
+                                                        <td>
+                                                            <ToggleSwitch
+                                                                inputTitle={t("alert.map")}
+                                                                label=""
+                                                                onChange={handleChange(i, "map")}
+                                                                checked={alert.visibility.map}
+                                                            />
+                                                        </td>
+                                                        <td>
+                                                            <ToggleSwitch
+                                                                inputTitle={t("alert.serviceLevel")}
+                                                                label=""
+                                                                onChange={handleChange(i, "serviceLevel")}
+                                                                checked={alert.visibility.serviceLevel}
+                                                            />
+                                                        </td>
+                                                        <td>
+                                                            <div>
+                                                                <Button
+                                                                    iconId="fr-icon-pencil-line"
+                                                                    priority="tertiary no outline"
+                                                                    title={t("update")}
+                                                                    type="button"
+                                                                    className={fr.cx("fr-mr-2v")}
+                                                                    onClick={openUpdateAlert(alert)}
+                                                                />
+                                                                <Button
+                                                                    iconId="fr-icon-delete-line"
+                                                                    priority="tertiary no outline"
+                                                                    title={t("delete")}
+                                                                    type="button"
+                                                                    onClick={deleteAlert(alert)}
+                                                                />
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    )}
                 />
                 {notification && (
                     <Alert
@@ -293,9 +319,9 @@ export default Alerts;
 
 /**
  * TODO
- * - problem with browser cache (use `cache: "no-store"` temporary)
  * - no alerts in table
  * - dashboard integration
+ * - problem with browser cache (use `cache: "no-store"` temporary)
  * - make const id configurable?
  * - menu integration?
  * - detail as rich text (markdown)

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -9,36 +9,46 @@ import { Controller, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 
-import { IAlert, INewAlert } from "../../../@types/alert";
+import { IAlert } from "../../../@types/alert";
 import DatastoreLayout from "../../../components/Layout/DatastoreLayout";
-import CreateAlert from "../../../components/Modal/CreateAlert/CreateAlert";
+import CreateAlert, { alertSchema } from "../../../components/Modal/CreateAlert/CreateAlert";
 import { useTranslation } from "../../../i18n";
 import { formatDateFromISO } from "../../../utils";
 
 import "./Alerts.scss";
-import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 
 const datastoreId = "5cb4fdb0-6f6c-4422-893d-e04564bfcc10";
 
+function getNewAlert() {
+    return {
+        id: crypto.randomUUID(),
+        title: "",
+        description: "",
+        link: { url: "", label: "" },
+        severity: "info" as const,
+        details: "",
+        date: new Date(),
+        visibility: {
+            homepage: false,
+            contact: false,
+            map: false,
+            serviceLevel: false,
+        },
+    };
+}
+
 const schema = yup.object({
-    visibility: yup.array().of(
-        yup.object({
-            homepage: yup.boolean(),
-            contact: yup.boolean(),
-            map: yup.boolean(),
-            serviceLevel: yup.boolean(),
-        })
-    ),
+    alerts: yup.array().of(alertSchema),
 });
 
-function getIcon(severity: IAlert["severity"]) {
+function getIcon(severity?: IAlert["severity"]) {
     switch (severity) {
-        case "success":
-            return <span className={[fr.cx("fr-icon-success-fill"), "alerts__icon--success"].join(" ")} title={severity} />;
-        case "warning":
-            return <span className={[fr.cx("fr-icon-warning-fill"), "alerts__icon--warning"].join(" ")} title={severity} />;
-        case "error":
-            return <span className={[fr.cx("fr-icon-error-warning-fill"), "alerts__icon--error"].join(" ")} title={severity} />;
+        // case "success":
+        //     return <span className={[fr.cx("fr-icon-success-fill"), "alerts__icon--success"].join(" ")} title={severity} />;
+        // case "warning":
+        //     return <span className={[fr.cx("fr-icon-warning-fill"), "alerts__icon--warning"].join(" ")} title={severity} />;
+        // case "error":
+        //     return <span className={[fr.cx("fr-icon-error-warning-fill"), "alerts__icon--error"].join(" ")} title={severity} />;
         default:
             return <span className={[fr.cx("fr-icon-info-fill"), "alerts__icon--info"].join(" ")} title={severity} />;
     }
@@ -50,35 +60,25 @@ const modal = createModal({
 });
 
 const Alerts: FC = () => {
-    const [alerts, setAlerts] = useState<IAlert[]>([]);
+    const [alert, setAlert] = useState<IAlert>(getNewAlert());
     const { t } = useTranslation("ConfigAlerts");
     const title = t("title");
 
-    const { control, getValues, handleSubmit, setValue } = useForm({
+    const { control, getValues, handleSubmit, setValue } = useForm<{ alerts?: IAlert[] }>({
         mode: "onSubmit",
-        defaultValues: { visibility: alerts.map((alert) => alert.visibility) },
+        defaultValues: { alerts: [] },
         resolver: yupResolver(schema),
     });
 
-    function handleAdd() {
-        modal.open();
-    }
-
     function handleChange(index: number, visibility: "homepage" | "contact" | "map" | "serviceLevel") {
         return (checked) => {
-            if (checked && (visibility === "homepage" || visibility === "contact")) {
-                const values = getValues("visibility");
-                if (values) {
-                    alerts.forEach((_, i) => {
-                        if (i !== index) {
-                            values[i][visibility] = false;
-                        }
-                    });
-                    values[index][visibility] = checked;
-                    setValue("visibility", values);
+            const alerts = getValues("alerts");
+            if (alerts) {
+                if (checked && (visibility === "homepage" || visibility === "contact")) {
+                    alerts.forEach((value) => (value.visibility[visibility] = false));
                 }
-            } else {
-                setValue(`visibility.${index}.${visibility}`, checked);
+                alerts[index].visibility[visibility] = checked;
+                setValue("alerts", alerts);
             }
         };
     }
@@ -87,9 +87,45 @@ const Alerts: FC = () => {
         console.log("submit", values);
     }
 
-    function addAlert(alert: INewAlert) {
-        setAlerts([...alerts, { ...alert, id: crypto.randomUUID() }]);
+    function addAlert() {
+        setAlert(getNewAlert());
+        setTimeout(() => modal.open(), 0);
+    }
+
+    function addOrUpdateAlert(alert: IAlert) {
+        const alerts = getValues("alerts") ?? [];
+        if (alert.visibility.homepage) {
+            alerts.forEach((value) => (value.visibility.homepage = false));
+        }
+        if (alert.visibility.contact) {
+            alerts.forEach((value) => (value.visibility.contact = false));
+        }
+        const index = alerts.findIndex((value) => value.id === alert.id);
+        if (index !== -1) {
+            alerts[index] = alert;
+        } else {
+            alerts.push({ ...alert, id: crypto.randomUUID() });
+        }
+        setValue("alerts", alerts);
         modal.close();
+    }
+
+    function updateAlert(alert: IAlert) {
+        return () => {
+            setAlert(alert);
+            setTimeout(() => modal.open(), 0);
+        };
+    }
+
+    function deleteAlert(alert: IAlert) {
+        return () => {
+            const alerts = getValues("alerts") ?? [];
+            const index = alerts.findIndex((value) => value.id === alert.id);
+            if (index !== -1) {
+                alerts.splice(index, 1);
+                setValue("alerts", alerts);
+            }
+        };
     }
 
     useEffect(() => {
@@ -106,75 +142,111 @@ const Alerts: FC = () => {
             <form onSubmit={handleSubmit(submitAlerts)}>
                 <div className="alerts__caption">
                     <h1>{title}</h1>
-                    <Button iconId={"fr-icon-add-line"} onClick={handleAdd} type="button">
+                    <Button iconId={"fr-icon-add-line"} onClick={addAlert} type="button">
                         {t("create_alert")}
                     </Button>
                 </div>
-                <Table
-                    className="alerts__table"
-                    fixed
-                    caption={t("table_caption")}
-                    noCaption
-                    data={alerts.map((alert, i) => [
-                        getIcon(alert.severity),
-                        alert.title,
-                        formatDateFromISO(alert.date.toISOString()),
-                        <Controller
-                            key="switch-homepage"
-                            control={control}
-                            name={`visibility.${i}.homepage`}
-                            render={({ field: { value } }) => (
-                                <ToggleSwitch inputTitle={t("alert.homepage")} label="" onChange={handleChange(i, "homepage")} checked={value} />
-                            )}
-                        />,
-                        <Controller
-                            key="switch-contact"
-                            control={control}
-                            name={`visibility.${i}.contact`}
-                            render={({ field: { value } }) => (
-                                <ToggleSwitch inputTitle={t("alert.contact")} label="" onChange={handleChange(i, "contact")} checked={value} />
-                            )}
-                        />,
-                        <Controller
-                            key="switch-map"
-                            control={control}
-                            name={`visibility.${i}.map`}
-                            render={({ field: { value } }) => (
-                                <ToggleSwitch inputTitle={t("alert.map")} label="" onChange={handleChange(i, "map")} checked={value} />
-                            )}
-                        />,
-                        <Controller
-                            key="switch-serviceLevel"
-                            control={control}
-                            name={`visibility.${i}.serviceLevel`}
-                            render={({ field: { value } }) => (
-                                <ToggleSwitch inputTitle={t("alert.serviceLevel")} label="" onChange={handleChange(i, "serviceLevel")} checked={value} />
-                            )}
-                        />,
-                        <div key="actions">
-                            <Button iconId="fr-icon-pencil-line" priority="tertiary no outline" title={t("update")} className={fr.cx("fr-mr-2v")} />
-                            <Button iconId="fr-icon-delete-line" priority="tertiary no outline" title={t("delete")} />
-                        </div>,
-                    ])}
-                    headers={[
-                        t("alert.severity"),
-                        t("alert.title"),
-                        t("alert.date"),
-                        t("alert.homepage"),
-                        t("alert.contact"),
-                        t("alert.map"),
-                        t("alert.serviceLevel"),
-                        t("actions"),
-                    ]}
+                <Controller
+                    control={control}
+                    name="alerts"
+                    render={({ field: { value: alerts } }) => {
+                        if (!alerts) {
+                            return <></>;
+                        }
+                        return (
+                            <Table
+                                className="alerts__table"
+                                fixed
+                                caption={t("table_caption")}
+                                noCaption
+                                data={alerts.map((alert, i) => [
+                                    getIcon(alert.severity),
+                                    alert.title,
+                                    formatDateFromISO(alert.date.toISOString()),
+                                    <ToggleSwitch
+                                        key="switch-homepage"
+                                        inputTitle={t("alert.homepage")}
+                                        label=""
+                                        onChange={handleChange(i, "homepage")}
+                                        checked={alert.visibility.homepage}
+                                    />,
+                                    <ToggleSwitch
+                                        key="switch-contact"
+                                        inputTitle={t("alert.contact")}
+                                        label=""
+                                        onChange={handleChange(i, "contact")}
+                                        checked={alert.visibility.contact}
+                                    />,
+                                    <ToggleSwitch
+                                        key="switch-map"
+                                        inputTitle={t("alert.map")}
+                                        label=""
+                                        onChange={handleChange(i, "map")}
+                                        checked={alert.visibility.map}
+                                    />,
+                                    <ToggleSwitch
+                                        key="switch-serviceLevel"
+                                        inputTitle={t("alert.serviceLevel")}
+                                        label=""
+                                        onChange={handleChange(i, "serviceLevel")}
+                                        checked={alert.visibility.serviceLevel}
+                                    />,
+                                    <div key="actions">
+                                        <Button
+                                            iconId="fr-icon-pencil-line"
+                                            priority="tertiary no outline"
+                                            title={t("update")}
+                                            type="button"
+                                            className={fr.cx("fr-mr-2v")}
+                                            onClick={updateAlert(alert)}
+                                        />
+                                        <Button
+                                            iconId="fr-icon-delete-line"
+                                            priority="tertiary no outline"
+                                            title={t("delete")}
+                                            type="button"
+                                            onClick={deleteAlert(alert)}
+                                        />
+                                    </div>,
+                                ])}
+                                headers={[
+                                    t("alert.severity"),
+                                    t("alert.title"),
+                                    t("alert.date"),
+                                    t("alert.homepage"),
+                                    t("alert.contact"),
+                                    t("alert.map"),
+                                    t("alert.serviceLevel"),
+                                    t("actions"),
+                                ]}
+                            />
+                        );
+                    }}
                 />
                 <Button iconId={"fr-icon-add-line"} type="submit">
                     {t("save")}
                 </Button>
             </form>
-            <CreateAlert ModalComponent={modal.Component} onSubmit={addAlert} />
+            <CreateAlert key={alert.id} alert={alert} isEdit={Boolean(alert.title)} ModalComponent={modal.Component} onSubmit={addOrUpdateAlert} />
         </DatastoreLayout>
     );
 };
 Alerts.displayName = symToStr({ Alerts });
 
 export default Alerts;
+
+/**
+ * TODO
+ * - update
+ * - no alerts in table
+ * - fetch alerts (json)
+ * - submit alerts (json)
+ * - make const id configurable
+ * - menu integration?
+ * - dashboard integration
+ * - display alert:
+ *   - homepage
+ *   - contact
+ *   - map?
+ *   - service level
+ */

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -75,7 +75,7 @@ const Alerts: FC = () => {
     const alerts = useAlertStore(({ alerts }) => alerts);
     const setAlerts = useAlertStore(({ setAlerts }) => setAlerts);
     const [alert, setAlert] = useState<IAlert>(getNewAlert());
-    const { t } = useTranslation("ConfigAlerts");
+    const { t } = useTranslation("alerts");
     const title = t("title");
     const [notification, setNotification] = useState<INotification | null>(null);
 
@@ -182,13 +182,8 @@ const Alerts: FC = () => {
     const closable = notification?.severity !== "warning";
     return (
         <DatastoreLayout datastoreId={datastoreId} documentTitle={title}>
-            {/* <div className={fr.cx("fr-grid-row")}>
-                <div className={fr.cx("fr-col")}>
-                    <h1>{title}</h1>
-                </div>
-            </div> */}
             <form onSubmit={handleSubmit(submitAlerts)}>
-                <div className="alerts__caption">
+                <div className={[fr.cx("fr-mb-5w"), "alerts__caption"].join(" ")}>
                     <h1>{title}</h1>
                     <Button iconId={"fr-icon-add-line"} onClick={openAddAlert} type="button">
                         {t("create_alert")}
@@ -272,7 +267,7 @@ const Alerts: FC = () => {
                 />
                 {notification && (
                     <Alert
-                        className="fr-mb-5w"
+                        className={fr.cx("fr-mb-5w")}
                         title={notification.title}
                         severity={notification.severity}
                         small={false}
@@ -298,15 +293,10 @@ export default Alerts;
 
 /**
  * TODO
- * - problem with browser cache
+ * - problem with browser cache (use `cache: "no-store"` temporary)
  * - no alerts in table
- * - datepicker (with time ?)
+ * - dashboard integration
  * - make const id configurable?
  * - menu integration?
- * - dashboard integration
- * - display alert:
- *   - homepage
- *   - contact
- *   - map?
- *   - service level
+ * - detail as rich text (markdown)
  */

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -1,0 +1,230 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { AlertProps } from "@codegouvfr/react-dsfr/Alert";
+import Table from "@codegouvfr/react-dsfr/Table";
+import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
+import { FC, useEffect, useState } from "react";
+import { symToStr } from "tsafe/symToStr";
+import { Controller, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+
+import DatastoreLayout from "../../../components/Layout/DatastoreLayout";
+import { useTranslation } from "../../../i18n";
+import { formatDateFromISO } from "../../../utils";
+
+import "./Alerts.scss";
+
+interface IAlert {
+    id: string;
+    title: string;
+    description: string;
+    link: { url: string; label: string };
+    severity: AlertProps["severity"];
+    details: string;
+    date: string;
+    visibility: {
+        homepage: boolean;
+        contact: boolean;
+        map: boolean;
+        serviceLevel: boolean;
+    };
+}
+
+const datastoreId = "5cb4fdb0-6f6c-4422-893d-e04564bfcc10";
+const mock: IAlert[] = [
+    {
+        id: "1",
+        title: "Titre d'alerte",
+        description: "Description de l'alerte",
+        link: { url: "https://example.com", label: "Lien vers la page" },
+        severity: "info",
+        details: "Détails supplémentaires",
+        date: "2023-06-02T06:01:46+00:00",
+        visibility: {
+            homepage: true,
+            contact: true,
+            map: true,
+            serviceLevel: true,
+        },
+    },
+    {
+        id: "2",
+        title: "Titre d'alerte",
+        description: "Description de l'alerte",
+        link: { url: "https://example.com", label: "Lien vers la page" },
+        severity: "warning",
+        details: "Détails supplémentaires",
+        date: "2023-06-03T06:01:46+00:00",
+        visibility: {
+            homepage: false,
+            contact: false,
+            map: true,
+            serviceLevel: true,
+        },
+    },
+    {
+        id: "3",
+        title: "Titre d'alerte",
+        description: "Description de l'alerte",
+        link: { url: "https://example.com", label: "Lien vers la page" },
+        severity: "error",
+        details: "Détails supplémentaires",
+        date: "2023-06-03T06:01:46+00:00",
+        visibility: {
+            homepage: false,
+            contact: false,
+            map: true,
+            serviceLevel: true,
+        },
+    },
+    {
+        id: "4",
+        title: "Titre d'alerte",
+        description: "Description de l'alerte",
+        link: { url: "https://example.com", label: "Lien vers la page" },
+        severity: "success",
+        details: "Détails supplémentaires",
+        date: "2023-06-03T06:01:46+00:00",
+        visibility: {
+            homepage: false,
+            contact: false,
+            map: true,
+            serviceLevel: true,
+        },
+    },
+];
+
+const schema = yup.object({
+    visibility: yup.array().of(
+        yup.object({
+            homepage: yup.boolean(),
+            contact: yup.boolean(),
+            map: yup.boolean(),
+            serviceLevel: yup.boolean(),
+        })
+    ),
+});
+
+function getIcon(severity: AlertProps["severity"]) {
+    switch (severity) {
+        case "success":
+            return <span className={[fr.cx("fr-icon-success-fill"), "alerts__icon--success"].join(" ")} title={severity} />;
+        case "warning":
+            return <span className={[fr.cx("fr-icon-warning-fill"), "alerts__icon--warning"].join(" ")} title={severity} />;
+        case "error":
+            return <span className={[fr.cx("fr-icon-error-warning-fill"), "alerts__icon--error"].join(" ")} title={severity} />;
+        default:
+            return <span className={[fr.cx("fr-icon-info-fill"), "alerts__icon--info"].join(" ")} title={severity} />;
+    }
+}
+
+const Alerts: FC = () => {
+    const [alerts, setAlerts] = useState(mock);
+    const { t } = useTranslation("ConfigAlerts");
+    const title = t("title");
+
+    const {
+        control,
+        setValue,
+        getValues,
+        formState: { errors },
+        watch,
+        handleSubmit,
+    } = useForm({ mode: "onSubmit", defaultValues: { visibility: alerts.map((alert) => alert.visibility) }, resolver: yupResolver(schema) });
+
+    function handleAdd() {
+        console.log("add");
+    }
+
+    function handleChange(index: number, visibility: "homepage" | "contact" | "map" | "serviceLevel") {
+        return (checked) => {
+            if (checked && (visibility === "homepage" || visibility === "contact")) {
+                const values = getValues("visibility");
+                if (values) {
+                    alerts.forEach((_, i) => {
+                        if (i !== index) {
+                            values[i][visibility] = false;
+                        }
+                    });
+                    values[index][visibility] = checked;
+                    setValue("visibility", values);
+                }
+            } else {
+                setValue(`visibility.${index}.${visibility}`, checked);
+            }
+        };
+    }
+
+    function submit(values) {
+        console.log("submit", values);
+    }
+
+    return (
+        <DatastoreLayout datastoreId={datastoreId} documentTitle={title}>
+            {/* <div className={fr.cx("fr-grid-row")}>
+                <div className={fr.cx("fr-col")}>
+                    <h1>{title}</h1>
+                </div>
+            </div> */}
+            <form onSubmit={handleSubmit(submit)}>
+                <div className="alerts__caption">
+                    <h1>{title}</h1>
+                    <Button iconId={"fr-icon-add-line"} onClick={handleAdd} type="button">
+                        {t("create_alert")}
+                    </Button>
+                </div>
+                <Table
+                    className="alerts__table"
+                    fixed
+                    caption={t("table_caption")}
+                    noCaption
+                    data={alerts.map((alert, i) => [
+                        getIcon(alert.severity),
+                        alert.title,
+                        formatDateFromISO(alert.date),
+                        <Controller
+                            key="switch-homepage"
+                            control={control}
+                            name={`visibility.${i}.homepage`}
+                            render={({ field: { value } }) => (
+                                <ToggleSwitch inputTitle={t("th.homepage")} label="" onChange={handleChange(i, "homepage")} checked={value} />
+                            )}
+                        />,
+                        <Controller
+                            key="switch-contact"
+                            control={control}
+                            name={`visibility.${i}.contact`}
+                            render={({ field: { value } }) => (
+                                <ToggleSwitch inputTitle={t("th.contact")} label="" onChange={handleChange(i, "contact")} checked={value} />
+                            )}
+                        />,
+                        <Controller
+                            key="switch-map"
+                            control={control}
+                            name={`visibility.${i}.map`}
+                            render={({ field: { value } }) => (
+                                <ToggleSwitch inputTitle={t("th.map")} label="" onChange={handleChange(i, "map")} checked={value} />
+                            )}
+                        />,
+                        <Controller
+                            key="switch-serviceLevel"
+                            control={control}
+                            name={`visibility.${i}.serviceLevel`}
+                            render={({ field: { value } }) => (
+                                <ToggleSwitch inputTitle={t("th.serviceLevel")} label="" onChange={handleChange(i, "serviceLevel")} checked={value} />
+                            )}
+                        />,
+                    ])}
+                    headers={[t("th.severity"), t("th.title"), t("th.date"), t("th.homepage"), t("th.contact"), t("th.map"), t("th.serviceLevel")]}
+                />
+                <Button iconId={"fr-icon-add-line"} type="submit">
+                    {t("enregistrer")}
+                </Button>
+            </form>
+        </DatastoreLayout>
+    );
+};
+Alerts.displayName = symToStr({ Alerts });
+
+export default Alerts;

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -1,7 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
 import Button from "@codegouvfr/react-dsfr/Button";
-import Table from "@codegouvfr/react-dsfr/Table";
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { FC, useMemo, useState } from "react";
@@ -319,8 +318,6 @@ export default Alerts;
 
 /**
  * TODO
- * - no alerts in table
- * - dashboard integration
  * - problem with browser cache (use `cache: "no-store"` temporary)
  * - make const id configurable?
  * - menu integration?

--- a/assets/entrepot/pages/dashboard/DashboardPro.locale.tsx
+++ b/assets/entrepot/pages/dashboard/DashboardPro.locale.tsx
@@ -3,7 +3,7 @@ import { declareComponentKeys } from "i18nifty";
 import { Translations } from "../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
-    "document_title" | "espaceco_frontoffice_list" | "datastore_for_tests" | "datastore_creation_form" | "join_existing_community"
+    "document_title" | "espaceco_frontoffice_list" | "datastore_for_tests" | "datastore_creation_form" | "join_existing_community" | "alerts"
 >()("DashboardPro");
 export type I18n = typeof i18n;
 
@@ -13,6 +13,7 @@ export const DashboardProFrTranslations: Translations<"fr">["DashboardPro"] = {
     datastore_for_tests: "À des fins de test",
     datastore_creation_form: "Demande de création d’un espace de travail",
     join_existing_community: "Rejoindre un espace de travail existant",
+    alerts: "Alertes",
 };
 
 export const DashboardProEnTranslations: Translations<"en">["DashboardPro"] = {
@@ -21,4 +22,5 @@ export const DashboardProEnTranslations: Translations<"en">["DashboardPro"] = {
     datastore_for_tests: "For testing purposes",
     datastore_creation_form: undefined,
     join_existing_community: undefined,
+    alerts: undefined,
 };

--- a/assets/entrepot/pages/dashboard/DashboardPro.tsx
+++ b/assets/entrepot/pages/dashboard/DashboardPro.tsx
@@ -32,6 +32,8 @@ const DashboardPro = () => {
     const setUser = useAuthStore((state) => state.setUser);
     const isApiEspaceCoDefined = useApiEspaceCoStore((state) => state.isUrlDefined);
 
+    const configDatastore = user?.communities_member?.find((community) => community.community?.datastore === api.alerts.datastoreId)?.community;
+
     const userQuery = useQuery<CartesUser, CartesApiException>({
         queryKey: RQKeys.user_me(),
         queryFn: ({ signal }) => api.user.getMe({ signal }),
@@ -160,7 +162,7 @@ const DashboardPro = () => {
                 )}
             </div>
 
-            <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+            <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mb-3w")}>
                 <div className={fr.cx("fr-col-12", "fr-col-sm-6")}>
                     <Tile
                         linkProps={routes.datastore_create_request().link}
@@ -182,6 +184,15 @@ const DashboardPro = () => {
                     />
                 </div>
             </div>
+
+            {configDatastore && (
+                <>
+                    <h2>Configuration</h2>
+                    <div key={configDatastore.datastore} className={fr.cx("fr-col-12", "fr-col-sm-6", "fr-col-md-4", "fr-col-lg-3")}>
+                        <Tile linkProps={routes.config_alerts().link} grey={true} title={t("alerts")} />
+                    </div>
+                </>
+            )}
 
             {isApiEspaceCoDefined() && (
                 <div className={fr.cx("fr-grid-row", "fr-grid-row--left", "fr-mt-4w")}>

--- a/assets/hooks/useAlert.tsx
+++ b/assets/hooks/useAlert.tsx
@@ -1,0 +1,32 @@
+import { fr } from "@codegouvfr/react-dsfr";
+
+import { IAlert } from "../@types/alert";
+import { useTranslation } from "../i18n";
+import { ReactNode } from "react";
+
+export function useAlert(alert?: IAlert): { isClosable: true; title: NonNullable<ReactNode> } | undefined {
+    const { t } = useTranslation("alerts");
+    if (!alert) {
+        return undefined;
+    }
+    const title = (
+        <>
+            {alert.title} {alert.description}
+            {alert.link.label && (
+                <>
+                    {" "}
+                    <a
+                        className={fr.cx("fr-notice__link")}
+                        href={alert.link.url}
+                        target="_blank"
+                        rel="noreferrer external"
+                        title={`${alert.link.label} - ${t("newWindow")}`}
+                    >
+                        {alert.link.label}
+                    </a>
+                </>
+            )}
+        </>
+    );
+    return { isClosable: true, title };
+}

--- a/assets/i18n/languages/en.tsx
+++ b/assets/i18n/languages/en.tsx
@@ -90,5 +90,5 @@ export const translations: Translations<"en"> = {
     DatasheetList: DatasheetListEnTranslations,
     AccessRestrictions: AccessRestrictionsEnTranslations,
     LoginDisabled: LoginDisabledEnTranslations,
-    ConfigAlerts: AlertsEnTranslations,
+    alerts: AlertsEnTranslations,
 };

--- a/assets/i18n/languages/en.tsx
+++ b/assets/i18n/languages/en.tsx
@@ -42,6 +42,7 @@ import { ContactEnTranslations } from "../../pages/assistance/contact/Contact.lo
 import { mapboxStyleValidationEnTranslations } from "../../validations/mapbox/MapboxStyleValidator.locale";
 import { SldStyleValidationErrorsEnTranslations } from "../../validations/sld/SldStyleValidation.locale";
 import { commonEnTranslations } from "../Common.locale";
+import { AlertsEnTranslations } from "../../entrepot/pages/config/Alerts.locale";
 import type { Translations } from "../types";
 
 export const translations: Translations<"en"> = {
@@ -89,4 +90,5 @@ export const translations: Translations<"en"> = {
     DatasheetList: DatasheetListEnTranslations,
     AccessRestrictions: AccessRestrictionsEnTranslations,
     LoginDisabled: LoginDisabledEnTranslations,
+    ConfigAlerts: AlertsEnTranslations,
 };

--- a/assets/i18n/languages/fr.tsx
+++ b/assets/i18n/languages/fr.tsx
@@ -42,6 +42,7 @@ import { ContactFrTranslations } from "../../pages/assistance/contact/Contact.lo
 import { mapboxStyleValidationFrTranslations } from "../../validations/mapbox/MapboxStyleValidator.locale";
 import { SldStyleValidationErrorsFrTranslations } from "../../validations/sld/SldStyleValidation.locale";
 import { commonFrTranslations } from "../Common.locale";
+import { AlertsFrTranslations } from "../../entrepot/pages/config/Alerts.locale";
 import type { Translations } from "../types";
 
 export const translations: Translations<"fr"> = {
@@ -89,4 +90,5 @@ export const translations: Translations<"fr"> = {
     DatasheetList: DatasheetListFrTranslations,
     AccessRestrictions: AccessRestrictionsFrTranslations,
     LoginDisabled: LoginDisabledFrTranslations,
+    ConfigAlerts: AlertsFrTranslations,
 };

--- a/assets/i18n/languages/fr.tsx
+++ b/assets/i18n/languages/fr.tsx
@@ -90,5 +90,5 @@ export const translations: Translations<"fr"> = {
     DatasheetList: DatasheetListFrTranslations,
     AccessRestrictions: AccessRestrictionsFrTranslations,
     LoginDisabled: LoginDisabledFrTranslations,
-    ConfigAlerts: AlertsFrTranslations,
+    alerts: AlertsFrTranslations,
 };

--- a/assets/i18n/types.ts
+++ b/assets/i18n/types.ts
@@ -58,6 +58,7 @@ export type ComponentKey =
     | import("../entrepot/pages/service/common/TableSelection/TableSelection.locale").I18n
     | import("../entrepot/pages/service/common/AccessRestrictions/AccessRestrictions.locale").I18n
     | import("../entrepot/pages/service/wms-vector/UploadStyleFile.locale").I18n
+    | import("../entrepot/pages/config/Alerts.locale").I18n
     | import("../espaceco/pages/communities/EspaceCoCommunities.locale").I18n
     | import("../pages/LoginDisabled/LoginDisabled.locale").I18n;
 

--- a/assets/modules/entrepot/RQKeys.ts
+++ b/assets/modules/entrepot/RQKeys.ts
@@ -59,6 +59,8 @@ const RQKeys = {
     my_document: (documentId: string): string[] => ["user", "me", "documents", documentId],
 
     accesses_request: (fileIdentifier: string): string[] => ["accesses_request", fileIdentifier],
+
+    alerts: (): string[] => ["alerts"],
 };
 
 export default RQKeys;

--- a/assets/pages/Home.tsx
+++ b/assets/pages/Home.tsx
@@ -19,10 +19,14 @@ import locationFranceSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms
 import mapSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/map/map.svg";
 import systemSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/system.svg";
 import homeImgUrl from "../img/home/home.png";
+import { useAlertStore } from "../stores/AlertStore";
+import { useAlert } from "../hooks/useAlert";
 
 const Home = () => {
     const { params } = useRoute();
     const user = useAuthStore((state) => state.user);
+    const alert = useAlertStore(({ alerts }) => alerts.find((alert) => alert.visibility.homepage));
+    const alertProps = useAlert(alert);
 
     useEffect(() => {
         if (user !== null && params?.["authentication_failed"] !== undefined) {
@@ -34,22 +38,8 @@ const Home = () => {
         }
     }, [params, user]);
 
-    const infoBannerMsg = (
-        <>
-            Devenez acteur de cartes.gouv.fr et co-construisez les fonctionnalités en participant à des ateliers thématiques.{" "}
-            <a
-                href="https://analytics-eu.clickdimensions.com/ignfr-agj1s/pages/dbg2dmemee4wanorp13w.html?PageId=0eb6b1752661ef11bfe3000d3aba75df"
-                target="_blank"
-                rel="noreferrer"
-                title="Formulaire d’inscription à des ateliers cartes.gouv.fr - Ouvre une nouvelle fenêtre"
-            >
-                Inscrivez-vous
-            </a>
-        </>
-    );
-
     return (
-        <AppLayout documentTitle="Le service public des cartes et données du territoire" infoBannerMsg={infoBannerMsg}>
+        <AppLayout documentTitle="Le service public des cartes et données du territoire" infoBannerMsg={alertProps?.title}>
             {params?.["authentication_failed"] === 1 && (
                 <Alert
                     severity="error"

--- a/assets/pages/assistance/ServiceStatus.tsx
+++ b/assets/pages/assistance/ServiceStatus.tsx
@@ -1,11 +1,25 @@
 import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
 import { useState } from "react";
 
 import AppLayout from "../../components/Layout/AppLayout";
 import LoadingIcon from "../../components/Utils/LoadingIcon";
+import { useAlertStore } from "../../stores/AlertStore";
+import { IAlert } from "../../@types/alert";
+
+const severityMap = {
+    alert: "error",
+};
+function getAlertSeverity(severity: IAlert["severity"]): "info" | "warning" | "error" {
+    if (severity in severityMap) {
+        return severityMap[severity];
+    }
+    return severity as Exclude<IAlert["severity"], "alert">;
+}
 
 const ServiceStatus = () => {
     const [loading, setLoading] = useState(true);
+    const alerts = useAlertStore(({ alerts }) => alerts);
 
     return (
         <AppLayout documentTitle="Niveau de service">
@@ -18,6 +32,9 @@ const ServiceStatus = () => {
                     </p>
                 </div>
             </div>
+            {alerts.map((alert) => (
+                <Alert key={alert.id} title={alert.title} severity={getAlertSeverity(alert.severity)} description={alert.details} />
+            ))}
             <div className={fr.cx("fr-grid-row")}>
                 <div className={fr.cx("fr-col-12")}>
                     <iframe src="https://status.uptrends.com/aa35b49e519e4f90866dc6bfc0a797a9" height="800px" width="100%" onLoad={() => setLoading(false)} />

--- a/assets/pages/assistance/contact/Contact.tsx
+++ b/assets/pages/assistance/contact/Contact.tsx
@@ -19,6 +19,8 @@ import { jsonFetch } from "../../../modules/jsonFetch";
 import { routes } from "../../../router/router";
 import { useAuthStore } from "../../../stores/AuthStore";
 import { regex } from "../../../utils";
+import { useAlertStore } from "../../../stores/AlertStore";
+import { useAlert } from "../../../hooks/useAlert";
 
 import "../../../sass/pages/nous_ecrire.scss";
 
@@ -42,6 +44,8 @@ const schema = (t: TranslationFunction<"Contact", ComponentKey>) =>
 const Contact = () => {
     const { t } = useTranslation({ Contact });
     const { user } = useAuthStore();
+    const alert = useAlertStore(({ alerts }) => alerts.find((alert) => alert.visibility.homepage));
+    const alertProps = useAlert(alert);
 
     const [isSending, setIsSending] = useState(false);
     const [error, setError] = useState(null);
@@ -76,7 +80,7 @@ const Contact = () => {
     };
 
     return (
-        <AppLayout documentTitle={t("title")}>
+        <AppLayout documentTitle={t("title")} infoBannerMsg={alertProps?.title}>
             <div className={fr.cx("fr-grid-row")}>
                 <div className={fr.cx("fr-col-12", "fr-col-md-8")}>
                     <h1>{t("title")}</h1>

--- a/assets/router/RouterRenderer.tsx
+++ b/assets/router/RouterRenderer.tsx
@@ -66,7 +66,7 @@ const ServiceView = lazy(() => import("../entrepot/pages/service/view/ServiceVie
 
 const AccessesRequest = lazy(() => import("../entrepot/pages/accesses-request/AccessesRequest"));
 
-const ConfigEvents = lazy(() => import("../entrepot/pages/config/Alerts"));
+const ConfigAlerts = lazy(() => import("../entrepot/pages/config/Alerts"));
 
 const EspaceCoCommunityList = lazy(() => import("../espaceco/pages/communities/Communities"));
 
@@ -244,8 +244,8 @@ const RouterRenderer: FC = () => {
                 );
             case "datastore_service_view":
                 return <ServiceView datastoreId={route.params.datastoreId} offeringId={route.params.offeringId} datasheetName={route.params.datasheetName} />;
-            case "config_events":
-                return <ConfigEvents />;
+            case "config_alerts":
+                return <ConfigAlerts />;
             case "espaceco_community_list":
                 return <EspaceCoCommunityList />;
             default:

--- a/assets/router/RouterRenderer.tsx
+++ b/assets/router/RouterRenderer.tsx
@@ -66,6 +66,8 @@ const ServiceView = lazy(() => import("../entrepot/pages/service/view/ServiceVie
 
 const AccessesRequest = lazy(() => import("../entrepot/pages/accesses-request/AccessesRequest"));
 
+const ConfigEvents = lazy(() => import("../entrepot/pages/config/Alerts"));
+
 const EspaceCoCommunityList = lazy(() => import("../espaceco/pages/communities/Communities"));
 
 const RouterRenderer: FC = () => {
@@ -242,6 +244,8 @@ const RouterRenderer: FC = () => {
                 );
             case "datastore_service_view":
                 return <ServiceView datastoreId={route.params.datastoreId} offeringId={route.params.offeringId} datasheetName={route.params.datasheetName} />;
+            case "config_events":
+                return <ConfigEvents />;
             case "espaceco_community_list":
                 return <EspaceCoCommunityList />;
             default:

--- a/assets/router/router.ts
+++ b/assets/router/router.ts
@@ -276,6 +276,8 @@ const routeDefs = {
         (p) => `${appRoot}/entrepot/${p.datastoreId}/service/${p.offeringId}/visualisation`
     ),
 
+    config_events: defineRoute(`${appRoot}/config/events`),
+
     espaceco_community_list: defineRoute(
         {
             page: param.query.optional.number.default(1),

--- a/assets/router/router.ts
+++ b/assets/router/router.ts
@@ -276,7 +276,7 @@ const routeDefs = {
         (p) => `${appRoot}/entrepot/${p.datastoreId}/service/${p.offeringId}/visualisation`
     ),
 
-    config_events: defineRoute(`${appRoot}/config/events`),
+    config_alerts: defineRoute(`${appRoot}/config/alerts`),
 
     espaceco_community_list: defineRoute(
         {

--- a/assets/stores/AlertStore.tsx
+++ b/assets/stores/AlertStore.tsx
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { IAlert } from "../@types/alert";
+
+interface AlertStore {
+    alerts: IAlert[];
+    setAlerts: (alerts: IAlert[]) => void;
+}
+
+export const useAlertStore = create<AlertStore>()((set) => ({
+    alerts: [],
+    setAlerts: (alerts) => set({ alerts }),
+}));

--- a/assets/utils.ts
+++ b/assets/utils.ts
@@ -164,6 +164,22 @@ const getFileExtension = (filename: string) => {
     return filename.split(".").pop()?.toLowerCase();
 };
 
+const formatDate = (date: Date): string => {
+    return datefnsFormat(date, "dd MMMM yyyy", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+};
+
+const formatDateTime = (date: Date): string => {
+    return (
+        datefnsFormat(date, "dd MMMM yyyy, HH", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }) +
+        "h" +
+        datefnsFormat(date, "mm", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })
+    );
+};
+
+const formatDateTimeLocal = (date: Date): string => {
+    return datefnsFormat(date, "yyyy-MM-dd'T'HH:mm", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+};
+
 const formatDateFromISO = (isoDateString: string): string => {
     const m = isoDateString.match(/([\d\-T:]+)\+\d{2}:\d{2}?/); // "2023-06-02T06:01:46+00:00"
     if (m) {
@@ -173,11 +189,7 @@ const formatDateFromISO = (isoDateString: string): string => {
 
     const d = new Date(isoDateString);
 
-    return (
-        datefnsFormat(d, "dd MMMM yyyy, HH", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone }) +
-        "h" +
-        datefnsFormat(d, "mm", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })
-    );
+    return formatDateTime(d);
 };
 
 const formatDateWithoutTimeFromISO = (isoDateString: string): string => {
@@ -189,7 +201,7 @@ const formatDateWithoutTimeFromISO = (isoDateString: string): string => {
 
     const d = new Date(isoDateString);
 
-    return datefnsFormat(d, "dd MMMM yyyy", { locale: fr, timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone });
+    return formatDate(d);
 };
 
 const getArrayRange = (start: number, stop: number, step: number = 1): number[] =>
@@ -243,6 +255,9 @@ export {
     niceBytes,
     getProjectionCode,
     getFileExtension,
+    formatDate,
+    formatDateTimeLocal,
+    formatDateTime,
     formatDateFromISO,
     formatDateWithoutTimeFromISO,
     getArrayRange,

--- a/src/Controller/Entrepot/AnnexeController.php
+++ b/src/Controller/Entrepot/AnnexeController.php
@@ -76,7 +76,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
         }
     }
 
-    #[Route('/{annexeId}', name: 'replace_file', methods: ['PUT'])]
+    #[Route('/{annexeId}', name: 'replace_file', methods: ['POST'])]
     public function replaceFile(string $datastoreId, string $annexeId, Request $request): JsonResponse
     {
         try {


### PR DESCRIPTION
Corrige #618
Il manque encore:
* integration texte riche pour le détail
* utilise `cache: "no-store"` pour charger le fichiers des alertes et éviter d'utiliser le cache navigateur qui pose problème
* faut-il afficher un menu spécifique quand on est dans la section de configuration ? actuellement on affiche le menu de l'entrepot "cartes.gouv.fr-config"