### PR TITLE
feat: key value component

### DIFF
--- a/assets/components/Input/KeyValueItem.tsx
+++ b/assets/components/Input/KeyValueItem.tsx
@@ -1,0 +1,118 @@
+import { useDragItem } from "@/hooks/useDrag";
+import { fr } from "@codegouvfr/react-dsfr";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
+import { tss } from "tss-react";
+import { useFormContext } from "react-hook-form";
+import { InputHTMLAttributes } from "react";
+import { get } from "@/utils";
+import Select, { SelectProps } from "@codegouvfr/react-dsfr/SelectNext";
+
+export interface KeyValue {
+    key?: string;
+    value: string | null;
+}
+
+export type KeyValues = KeyValue[];
+
+interface KeyValueListProps {
+    index: number;
+    name: string;
+    onRemove: (index: number) => void;
+    valueInputProps?: InputHTMLAttributes<HTMLInputElement>;
+    valueOptions?: SelectProps.Option[];
+    valueType?: "textInput" | "select";
+}
+
+function KeyValueItem(props: KeyValueListProps) {
+    const { index, name, onRemove, valueInputProps, valueOptions = [], valueType = "textInput" } = props;
+    const { dragIndex, ref, startDrag } = useDragItem();
+    const { classes, cx } = useStyles({ active: dragIndex === index });
+    const {
+        formState: { errors },
+        register,
+        watch,
+    } = useFormContext();
+    const useKeys = watch(`${name}.useKeys`);
+    const keyError = get(errors, `${name}.values.${index}.key.message`);
+    const valueError = get(errors, `${name}.values.${index}.value.message`);
+
+    function handleMove(index: number) {
+        return (event) => startDrag(event, index);
+    }
+
+    function handleRemove(index: number) {
+        return () => onRemove(index);
+    }
+
+    return (
+        <div className={cx(fr.cx("fr-pb-1w"), classes.row, classes.drag)} ref={ref}>
+            <div>
+                <Button
+                    title="Ordonner"
+                    priority={"tertiary no outline"}
+                    iconId={"ri-draggable"}
+                    nativeButtonProps={{ onMouseDown: handleMove(index) }}
+                    type="button"
+                />
+            </div>
+            {useKeys && (
+                <div className={classes.cell}>
+                    <Input
+                        label="Clé"
+                        nativeInputProps={register(`${name}.values.${index}.key`)}
+                        state={keyError ? "error" : "default"}
+                        stateRelatedMessage={String(keyError ?? "")}
+                    />
+                </div>
+            )}
+            <div className={classes.cell}>
+                {valueType === "textInput" && (
+                    <Input
+                        label="Valeur"
+                        nativeInputProps={{
+                            ...valueInputProps,
+                            ...register(`${name}.values.${index}.value`),
+                        }}
+                        state={valueError ? "error" : "default"}
+                        stateRelatedMessage={String(valueError ?? "")}
+                    />
+                )}
+                {valueType === "select" && (
+                    <Select
+                        label="Valeur"
+                        placeholder="Select an option"
+                        nativeSelectProps={register(`${name}.values.${index}.value`)}
+                        options={valueOptions}
+                        state={valueError ? "error" : "default"}
+                        stateRelatedMessage={String(valueError ?? "")}
+                    />
+                )}
+            </div>
+            <div>
+                <Button title="Supprimer" priority={"tertiary no outline"} iconId={"fr-icon-delete-line"} onClick={handleRemove(index)} />
+            </div>
+        </div>
+    );
+}
+
+export default KeyValueItem;
+
+const useStyles = tss.withParams<{ active: boolean }>().create(({ active }) => ({
+    drag: {
+        position: "relative",
+        zIndex: active ? 1 : 0,
+        scale: active ? 1.01 : 1,
+    },
+    row: {
+        display: "flex",
+        gap: "1.5rem",
+        alignItems: "center",
+    },
+    cell: {
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        height: "104px",
+    },
+}));

--- a/assets/contexts/drag.tsx
+++ b/assets/contexts/drag.tsx
@@ -1,0 +1,21 @@
+import { createContext, PropsWithChildren, useContext } from "react";
+
+export interface IDragContext {
+    dragIndex: number;
+    register: (ref: HTMLElement) => void;
+    startDrag: (event: MouseEvent, index: number) => void;
+}
+
+const dragContext = createContext<IDragContext | null>(null);
+
+export function DragProvider({ children, value }: PropsWithChildren<{ value: IDragContext }>) {
+    return <dragContext.Provider value={value}>{children}</dragContext.Provider>;
+}
+
+export function useDragContext() {
+    const context = useContext(dragContext);
+    if (!context) {
+        throw new Error("useDragContext must be used within a DragProvider");
+    }
+    return context;
+}

--- a/assets/hooks/useDrag.tsx
+++ b/assets/hooks/useDrag.tsx
@@ -1,0 +1,106 @@
+import { useDragContext } from "@/contexts/drag";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+function getNextPrev(index: number, positions: Map<HTMLElement, number>) {
+    const sortedPositions = [...positions.entries()].sort(([, a], [, b]) => a - b);
+    const prev = sortedPositions[index - 1];
+    const next = sortedPositions[index + 1];
+    return { prevRef: prev?.[0], prevPosition: prev?.[1], nextRef: next?.[0], nextPosition: next?.[1] };
+}
+
+export function useDrag(updateItems: (from: number, to: number) => void) {
+    const [dragIndex, setDragIndex] = useState(-1);
+    const refs = useRef<HTMLElement[]>([]);
+
+    const register = useCallback((ref: HTMLElement) => {
+        if (!refs.current.includes(ref)) {
+            refs.current.push(ref);
+            return () => refs.current.splice(refs.current.indexOf(ref), 1);
+        }
+    }, []);
+
+    const startDrag = useCallback(
+        (event: MouseEvent, index: number) => {
+            const ref = refs.current[index];
+            if (!ref) {
+                return;
+            }
+
+            const startIndex = index;
+            setDragIndex(index);
+            const startY = event.pageY;
+            const positions = new Map(
+                refs.current.map((ref) => {
+                    const { height, top } = ref.getBoundingClientRect();
+                    return [ref, top + height / 2];
+                }) as [HTMLElement, number][]
+            );
+            const deltas = new Map(refs.current.map((ref) => [ref, 0]));
+            const { height, top } = ref.getBoundingClientRect();
+            const position = top + height / 2;
+            let { nextPosition, nextRef, prevPosition, prevRef } = getNextPrev(index, positions);
+
+            function onDrag(event) {
+                const deltaY = event.pageY - startY;
+                ref.style.transform = `translateY(${deltaY}px)`;
+                const newPosition = position + deltaY;
+                positions.set(ref, position + deltaY);
+                // Swap with above item
+                if (prevPosition !== undefined && newPosition < prevPosition) {
+                    if (deltas.get(prevRef) === 0) {
+                        prevRef.style.translate = `0 ${height}px`;
+                        deltas.set(prevRef, height);
+                    } else {
+                        prevRef.style.translate = "0 0";
+                        deltas.set(prevRef, 0);
+                    }
+                    positions.set(prevRef, prevPosition + height);
+                    index--;
+                    ({ nextPosition, nextRef, prevPosition, prevRef } = getNextPrev(index, positions));
+                }
+                // Swap with below item
+                if (nextPosition !== undefined && newPosition > nextPosition) {
+                    if (deltas.get(nextRef) === 0) {
+                        nextRef.style.translate = `0 ${-height}px`;
+                        deltas.set(nextRef, -height);
+                    } else {
+                        nextRef.style.translate = "0 0";
+                        deltas.set(nextRef, 0);
+                    }
+                    positions.set(nextRef, nextPosition - height);
+                    index++;
+                    ({ nextPosition, nextRef, prevPosition, prevRef } = getNextPrev(index, positions));
+                }
+            }
+
+            function endDrag() {
+                window.removeEventListener("mousemove", onDrag);
+                ref.style.transform = "translateY(0)";
+                for (const [ref, delta] of deltas.entries()) {
+                    if (delta) {
+                        ref.style.translate = "0 0";
+                    }
+                }
+                setDragIndex(-1);
+                updateItems(startIndex, index);
+            }
+
+            window.addEventListener("mousemove", onDrag);
+            window.addEventListener("mouseup", endDrag, { once: true });
+        },
+        [updateItems]
+    );
+
+    return useMemo(() => ({ dragIndex, register, startDrag }), [dragIndex, register, startDrag]);
+}
+
+export function useDragItem() {
+    const { dragIndex, register, startDrag } = useDragContext();
+    const ref = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (ref.current) {
+            return register(ref.current);
+        }
+    }, [register]);
+    return { dragIndex, ref, startDrag };
+}

--- a/assets/hooks/useKeyValue.tsx
+++ b/assets/hooks/useKeyValue.tsx
@@ -1,0 +1,18 @@
+import { KeyValuesForm } from "@/components/Input/KeyValueList";
+
+type Data = (string | null)[] | Record<string, string | null>;
+
+export function useKeyValue(data: Data) {
+    const useKeys = !(data instanceof Array);
+    return {
+        keyValue: {
+            useKeys,
+            values:
+                data instanceof Array
+                    ? data.map((item) => ({ key: item ?? "", value: item ?? "" }))
+                    : Object.entries(data).map(([key, value]) => ({ key, value: value ?? "" })),
+        },
+        transformKeyValue: ({ useKeys, values }: KeyValuesForm): Data =>
+            useKeys ? Object.fromEntries(values.map(({ key, value }) => [key, value || null])) : values.map(({ value }) => value || null),
+    };
+}

--- a/assets/utils/format.ts
+++ b/assets/utils/format.ts
@@ -92,3 +92,21 @@ export const trimObject = (obj: object): object => {
 
     return newObject;
 };
+
+export function formatErrors(errors: unknown): string | undefined {
+    if (errors instanceof Array) {
+        const message = errors
+            .filter((x) => x)
+            .map(formatErrors)
+            .join(", ");
+        return message;
+    } else if (errors instanceof Object) {
+        if ("message" in errors) {
+            return errors.message as string;
+        } else if ("value" in errors) {
+            return formatErrors(errors.value);
+        } else {
+            return Object.values(errors).map(formatErrors).join(", ");
+        }
+    }
+}

--- a/assets/utils/types.ts
+++ b/assets/utils/types.ts
@@ -5,3 +5,27 @@ export const getFileExtension = (filename: string) => {
 
 export const getArrayRange = (start: number, stop: number, step: number = 1): number[] =>
     Array.from({ length: (stop - start) / step + 1 }, (_, index) => start + index * step);
+
+const rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+const reEscapeChar = /\\(\\)?/g;
+export function stringToPath(string) {
+    const result: string[] = [];
+    if (string.charCodeAt(0) === 46 /* . */) {
+        result.push("");
+    }
+    string.replace(rePropName, (match, number, quote, subString) => {
+        result.push(quote ? subString.replace(reEscapeChar, "$1") : number || match);
+    });
+    return result;
+}
+
+export function get(object: object, path: string): unknown | undefined {
+    const pathArray = stringToPath(path);
+    const length = pathArray.length;
+    let index = 0;
+    let result: unknown | undefined = object;
+    while (result !== undefined && result !== null && index < length) {
+        result = result?.[pathArray[index++]];
+    }
+    return index && index === length ? result : undefined;
+}


### PR DESCRIPTION
PR pour l'issue #643

Utilisation:
```tsx
import KeyValueList, { getKeyValueSchema } from "@/components/Input/KeyValueList";

const schema = yup.object({
  // use the getKeyValueSchema function to get the yup schema for the KeyValueList component 
  keyValue: getKeyValueSchema([
    { name: "isInteger", message: "value is not an integer", test: isInteger }, // you can add validators for the value field
  ]),
});

function Form() {
    const [data, setData] = useData(); // Get data from API (this is just for example, you probable want to use useQuery)
    const { keyValue, transformKeyValue } = useKeyValue(data); // Transform data from API to match keyValue schema
    const methods = useForm({
        mode: "onSubmit",
        resolver: yupResolver(schema),
        values: { keyValue },
    }); // Init form
    const { handleSubmit } = methods;
    const onSubmit = handleSubmit((values) => {
        console.log("onSubmit", values);
        // use the transformKeyValue function to transform from the keyValue schema back to array or object initial form
        setData(transformKeyValue(values.keyValue));
    });

    // You need to set up the FormProvider for the KeyValueList to access the form context
    return (
        <FormProvider {...methods}>
            <form onSubmit={onSubmit}>
                <h2>Form</h2>
                <KeyValueList label="Valeurs de la BDD"  name="keyValue"/>
                <Button type="submit">Enregistrer</Button>
                <pre>{JSON.stringify(data, null, 2)}</pre>
            </form>
        </FormProvider>
    );
}
```

Features:
- permet de gérer des listes de valeurs (array)
- permet de gérer des listes de clé/valeurs (object)
- bouton switch pour passer du mode array au mode object
- ajout/suppression de lignes
- drag and drop pour réordonner la liste
- fournit un schema yup prêt à l'emploi
- le schéma yup intègre un validateur pour éviter les doublons (pour les valeurs si array ou pour les clés si object)
- possible de passer des props au composant input pour les valeurs (par exemple `{ type: "date" }`)
- possible d'utiliser un select pour les valeurs et de fournir les options 