### PR TITLE
feat: message visu des flux privés

### DIFF
--- a/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
+++ b/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
@@ -13,7 +13,7 @@ function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationPro
     return (
         <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-grid-row--center", "fr-grid-row--middle")}>
             <div className={fr.cx("fr-py-0", "fr-col-12", "fr-col-md-6")}>
-                <p className={fr.cx("fr-text--lead", "fr-mb-3w")}>Ce service est privé et ne peux donc pas être affiché sur cartes.gouv.fr.</p>
+                <p className={fr.cx("fr-text--lead", "fr-mb-3w")}>Ce service est privé et ne peut donc pas être affiché sur cartes.gouv.fr.</p>
 
                 <p className={fr.cx("fr-text--sm")}>
                     Vous pouvez utiliser un logiciel SIG (Système d’Information Géographique) pour le visualiser. Au préalable vous devez créer une clé d’accès

--- a/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
+++ b/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from "@/i18n";
+import { routes } from "@/router/router";
+
+type PrivateServiceExplanationProps = {
+    datastoreId: string;
+};
+function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationProps) {
+    const { t: tCommon } = useTranslation("Common");
+
+    return (
+        <>
+            <p>
+                Ce service est privé et ne peut pas être visualisé directement sur cartes.gouv.fr. Cependant, il peut être visualisé dans un Système
+                d’Information Géographique (SIG). Pour ce faire, vous devez d’abord créer une permission et ensuite créer une clé d’accès.
+            </p>
+            <p>
+                Si le service a été créé sur cartes.gouv.fr, une permission a été automatiquement créée pour la communauté courante. Sinon, vous pouvez en créer
+                une pour votre communauté soit en utilisant <a {...routes.datastore_add_permission({ datastoreId }).link}>ce formulaite</a>, soit en passant par
+                l’API Entrepôt en suivant ce tutoriel :{" "}
+                <a
+                    href="https://geoplateforme.github.io/tutoriels/production/controle-des-acces/diffusion/permission/"
+                    target="_blank"
+                    rel="noreferrer"
+                    title={tCommon("new_window")}
+                >
+                    Gestion des permissions
+                </a>
+                . Vous pouvez consulter vos permissions sur la page <a {...routes.my_permissions().link}>Mes permissions</a>.
+            </p>
+
+            <p>
+                Ensuite, vous devez créer une clé d’accès soit en utilisant <a {...routes.user_key_add().link}>ce formulaite</a>, soit en passant par l’API
+                Entrepôt en suivant ce tutoriel :{" "}
+                <a
+                    href="https://geoplateforme.github.io/tutoriels/production/controle-des-acces/diffusion/cle/"
+                    target="_blank"
+                    rel="noreferrer"
+                    title={tCommon("new_window")}
+                >
+                    Gestion des clés
+                </a>
+                . Vous pouvez consulter vos clés sur la page <a {...routes.my_access_keys().link}>Mes clés d’accès</a>.
+            </p>
+            <p>
+                Vous pouvez ensuite récupérer l’URL du service avec la clé sur la page Mes clés d’accès et l’utiliser pour visualiser votre service privé dans
+                un SIG.
+            </p>
+        </>
+    );
+}
+
+export default PrivateServiceExplanation;

--- a/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
+++ b/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
@@ -1,9 +1,9 @@
 import { routes } from "@/router/router";
 
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 
-import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg";
+import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg?no-inline";
 import padlockSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/padlock.svg?no-inline";
 
 type PrivateServiceExplanationProps = {
@@ -27,21 +27,25 @@ function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationPro
                     puissent créer leur propre clé.
                 </p>
 
-                <ul className={fr.cx("fr-btns-group", "fr-btns-group--inline-md")}>
-                    <li>
-                        <Button {...routes.my_access_keys().link}>Voir mes clé d’accès</Button>
-                    </li>
-                    <li>
-                        <Button {...routes.datastore_add_permission({ datastoreId }).link} className={fr.cx("fr-btn--secondary")}>
-                            Configurer les permissions
-                        </Button>
-                    </li>
-                </ul>
+                <ButtonsGroup
+                    buttons={[
+                        {
+                            children: "Voir mes clé d’accès",
+                            linkProps: routes.my_access_keys().link,
+                        },
+                        {
+                            children: "Configurer les permissions",
+                            linkProps: routes.datastore_add_permission({ datastoreId }).link,
+                            priority: "secondary",
+                        },
+                    ]}
+                    inlineLayoutWhen="md and up"
+                />
             </div>
             <div className={fr.cx("fr-col-12", "fr-col-md-3", "fr-col-offset-md-1", "fr-px-6w", "fr-px-md-0", "fr-py-0")}>
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    className={"fr-responsive-img fr-artwork"}
+                    className={fr.cx("fr-responsive-img", "fr-artwork")}
                     aria-hidden="true"
                     width="160"
                     height="200"

--- a/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
+++ b/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
@@ -4,7 +4,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 
 import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg";
-import locationFranceSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/map/location-france.svg";
+import padlockSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/padlock.svg?no-inline";
 
 type PrivateServiceExplanationProps = {
     datastoreId: string;
@@ -13,25 +13,27 @@ function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationPro
     return (
         <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-grid-row--center", "fr-grid-row--middle")}>
             <div className={fr.cx("fr-py-0", "fr-col-12", "fr-col-md-6")}>
-                <p className={fr.cx("fr-text--lead", "fr-mb-3w")}>Ce service est privé et ne peut donc pas être affiché sur cartes.gouv.fr.</p>
+                <h2>Service privé</h2>
+
+                <p className={fr.cx("fr-text--lead", "fr-mb-3w")}>Ce service est privé et ne peut être affiché sur cartes.gouv.fr.</p>
 
                 <p className={fr.cx("fr-text--sm")}>
-                    Vous pouvez utiliser un logiciel SIG (Système d’Information Géographique) pour le visualiser. Au préalable vous devez créer une clé d’accès
-                    ou modifier une de vos clés d’accès existantes.
+                    Vous pouvez visualiser ce service sous un logiciel SIG (Système d’Information Géographique) à l’aide d’une clé d’accès. Vous pouvez créer,
+                    modifier ou retrouver toutes vos clés d’accès depuis votre tableau de bord.
                 </p>
 
                 <p className={fr.cx("fr-text--sm", "fr-mb-5w")}>
-                    Pour donner accès à d’autres personnes, vous pouvez leur donner une permission individuelle ou donner une permission à une communauté dont
-                    elles sont membres. Elles pourront ensuite configurer leurs propres clés.
+                    Si vous souhaitez partager ce service avec d’autres personnes, il est nécessaire de configurer au préalable les permissions afin qu’elles
+                    puissent créer leur propre clé.
                 </p>
 
                 <ul className={fr.cx("fr-btns-group", "fr-btns-group--inline-md")}>
                     <li>
-                        <Button {...routes.my_access_keys().link}>Ajouter ou modifier une clé d’accès</Button>
+                        <Button {...routes.my_access_keys().link}>Voir mes clé d’accès</Button>
                     </li>
                     <li>
                         <Button {...routes.datastore_add_permission({ datastoreId }).link} className={fr.cx("fr-btn--secondary")}>
-                            Configurer des permissions
+                            Configurer les permissions
                         </Button>
                     </li>
                 </ul>
@@ -48,9 +50,9 @@ function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationPro
                     <use className={fr.cx("fr-artwork-motif")} href={`${ovoidSvgUrl}#artwork-motif`} />
                     <use className={fr.cx("fr-artwork-background")} href={`${ovoidSvgUrl}#artwork-background`} />
                     <g transform="translate(40, 60)">
-                        <use className={fr.cx("fr-artwork-decorative")} href={`${locationFranceSvgUrl}#artwork-decorative`} />
-                        <use className={fr.cx("fr-artwork-minor")} href={`${locationFranceSvgUrl}#artwork-minor`} />
-                        <use className={fr.cx("fr-artwork-major")} href={`${locationFranceSvgUrl}#artwork-major`} />
+                        <use className={fr.cx("fr-artwork-decorative")} href={`${padlockSvgUrl}#artwork-decorative`} />
+                        <use className={fr.cx("fr-artwork-minor")} href={`${padlockSvgUrl}#artwork-minor`} />
+                        <use className={fr.cx("fr-artwork-major")} href={`${padlockSvgUrl}#artwork-major`} />
                     </g>
                 </svg>
             </div>

--- a/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
+++ b/assets/entrepot/pages/service/view/PrivateServiceExplanation.tsx
@@ -1,51 +1,60 @@
-import { useTranslation } from "@/i18n";
 import { routes } from "@/router/router";
+
+import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+
+import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg";
+import locationFranceSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/map/location-france.svg";
 
 type PrivateServiceExplanationProps = {
     datastoreId: string;
 };
 function PrivateServiceExplanation({ datastoreId }: PrivateServiceExplanationProps) {
-    const { t: tCommon } = useTranslation("Common");
-
     return (
-        <>
-            <p>
-                Ce service est privé et ne peut pas être visualisé directement sur cartes.gouv.fr. Cependant, il peut être visualisé dans un Système
-                d’Information Géographique (SIG). Pour ce faire, vous devez d’abord créer une permission et ensuite créer une clé d’accès.
-            </p>
-            <p>
-                Si le service a été créé sur cartes.gouv.fr, une permission a été automatiquement créée pour la communauté courante. Sinon, vous pouvez en créer
-                une pour votre communauté soit en utilisant <a {...routes.datastore_add_permission({ datastoreId }).link}>ce formulaite</a>, soit en passant par
-                l’API Entrepôt en suivant ce tutoriel :{" "}
-                <a
-                    href="https://geoplateforme.github.io/tutoriels/production/controle-des-acces/diffusion/permission/"
-                    target="_blank"
-                    rel="noreferrer"
-                    title={tCommon("new_window")}
-                >
-                    Gestion des permissions
-                </a>
-                . Vous pouvez consulter vos permissions sur la page <a {...routes.my_permissions().link}>Mes permissions</a>.
-            </p>
+        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-grid-row--center", "fr-grid-row--middle")}>
+            <div className={fr.cx("fr-py-0", "fr-col-12", "fr-col-md-6")}>
+                <p className={fr.cx("fr-text--lead", "fr-mb-3w")}>Ce service est privé et ne peux donc pas être affiché sur cartes.gouv.fr.</p>
 
-            <p>
-                Ensuite, vous devez créer une clé d’accès soit en utilisant <a {...routes.user_key_add().link}>ce formulaite</a>, soit en passant par l’API
-                Entrepôt en suivant ce tutoriel :{" "}
-                <a
-                    href="https://geoplateforme.github.io/tutoriels/production/controle-des-acces/diffusion/cle/"
-                    target="_blank"
-                    rel="noreferrer"
-                    title={tCommon("new_window")}
+                <p className={fr.cx("fr-text--sm")}>
+                    Vous pouvez utiliser un logiciel SIG (Système d’Information Géographique) pour le visualiser. Au préalable vous devez créer une clé d’accès
+                    ou modifier une de vos clés d’accès existantes.
+                </p>
+
+                <p className={fr.cx("fr-text--sm", "fr-mb-5w")}>
+                    Pour donner accès à d’autres personnes, vous pouvez leur donner une permission individuelle ou donner une permission à une communauté dont
+                    elles sont membres. Elles pourront ensuite configurer leurs propres clés.
+                </p>
+
+                <ul className={fr.cx("fr-btns-group", "fr-btns-group--inline-md")}>
+                    <li>
+                        <Button {...routes.my_access_keys().link}>Ajouter ou modifier une clé d’accès</Button>
+                    </li>
+                    <li>
+                        <Button {...routes.datastore_add_permission({ datastoreId }).link} className={fr.cx("fr-btn--secondary")}>
+                            Configurer des permissions
+                        </Button>
+                    </li>
+                </ul>
+            </div>
+            <div className={fr.cx("fr-col-12", "fr-col-md-3", "fr-col-offset-md-1", "fr-px-6w", "fr-px-md-0", "fr-py-0")}>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className={"fr-responsive-img fr-artwork"}
+                    aria-hidden="true"
+                    width="160"
+                    height="200"
+                    viewBox="0 0 160 200"
                 >
-                    Gestion des clés
-                </a>
-                . Vous pouvez consulter vos clés sur la page <a {...routes.my_access_keys().link}>Mes clés d’accès</a>.
-            </p>
-            <p>
-                Vous pouvez ensuite récupérer l’URL du service avec la clé sur la page Mes clés d’accès et l’utiliser pour visualiser votre service privé dans
-                un SIG.
-            </p>
-        </>
+                    <use className={fr.cx("fr-artwork-motif")} href={`${ovoidSvgUrl}#artwork-motif`} />
+                    <use className={fr.cx("fr-artwork-background")} href={`${ovoidSvgUrl}#artwork-background`} />
+                    <g transform="translate(40, 60)">
+                        <use className={fr.cx("fr-artwork-decorative")} href={`${locationFranceSvgUrl}#artwork-decorative`} />
+                        <use className={fr.cx("fr-artwork-minor")} href={`${locationFranceSvgUrl}#artwork-minor`} />
+                        <use className={fr.cx("fr-artwork-major")} href={`${locationFranceSvgUrl}#artwork-major`} />
+                    </g>
+                </svg>
+            </div>
+        </div>
     );
 }
 

--- a/assets/entrepot/pages/service/view/ServiceView.tsx
+++ b/assets/entrepot/pages/service/view/ServiceView.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { FC, useEffect, useMemo, useState } from "react";
 
 import { type CartesStyle, OfferingStatusEnum, OfferingTypeEnum, type Service, StoredDataTypeEnum, type TypeInfosWithBbox } from "../../../../@types/app";
+import Main from "../../../../components/Layout/Main";
 import LoadingText from "../../../../components/Utils/LoadingText";
 import type { MapInitial } from "../../../../components/Utils/RMap";
 import RMap from "../../../../components/Utils/RMap";
@@ -17,9 +18,9 @@ import { routes, useRoute } from "../../../../router/router";
 import api from "../../../api";
 import DiffuseServiceTab from "./DiffuseServiceTab";
 import ManageStylesTab from "./ManageStylesTab";
+import PrivateServiceExplanation from "./PrivateServiceExplanation";
 
 import "../../../../sass/pages/service_view.scss";
-import Main from "../../../../components/Layout/Main";
 
 type ServiceViewProps = {
     datastoreId: string;
@@ -40,7 +41,7 @@ const ServiceView: FC<ServiceViewProps> = ({ datastoreId, offeringId, datasheetN
     const [currentStyle, setCurrentStyle] = useState<CartesStyle | undefined>();
 
     useEffect(() => {
-        if (!serviceQuery.data) return;
+        if (!serviceQuery.data || serviceQuery.data?.open === false) return;
 
         let initial: MapInitial = { type: serviceQuery.data.type, bbox: undefined, layers: [] };
 
@@ -151,12 +152,22 @@ const ServiceView: FC<ServiceViewProps> = ({ datastoreId, offeringId, datasheetN
                         </div>
                     )}
 
-                    <div className={fr.cx("fr-grid-row", "fr-mb-4w")}>
-                        <div className={fr.cx("fr-col-12", "fr-col-md-8")}>{initialValues && <RMap initial={initialValues} currentStyle={currentStyle} />}</div>
-                        <div className={fr.cx("fr-col-12", "fr-col-md-4", "fr-p-1w", "fr-px-2w")}>
-                            <Tabs tabs={tabs} />
+                    {serviceQuery.data?.open === true ? (
+                        <div className={fr.cx("fr-grid-row", "fr-mb-4w")}>
+                            <div className={fr.cx("fr-col-12", "fr-col-md-8")}>
+                                {initialValues && <RMap initial={initialValues} currentStyle={currentStyle} />}
+                            </div>
+                            <div className={fr.cx("fr-col-12", "fr-col-md-4", "fr-p-1w", "fr-px-2w")}>
+                                <Tabs tabs={tabs} />
+                            </div>
                         </div>
-                    </div>
+                    ) : (
+                        <div className={fr.cx("fr-grid-row", "fr-mb-4w")}>
+                            <div className={fr.cx("fr-col")}>
+                                <PrivateServiceExplanation datastoreId={datastoreId} />
+                            </div>
+                        </div>
+                    )}
                 </>
             )}
         </Main>

--- a/assets/pages/error/PageNotFound.tsx
+++ b/assets/pages/error/PageNotFound.tsx
@@ -1,11 +1,12 @@
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
+import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { FC } from "react";
-import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg";
-import technicalErrorSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg";
 
-import { routes } from "../../router/router";
-import Main from "../../components/Layout/Main";
+import Main from "@/components/Layout/Main";
+import { routes } from "@/router/router";
+
+import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg?no-inline";
+import technicalErrorSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg?no-inline";
 
 const PageNotFound: FC = () => {
     return (
@@ -34,21 +35,25 @@ const PageNotFound: FC = () => {
                         bonne information.
                     </p>
 
-                    <ul className={fr.cx("fr-btns-group", "fr-btns-group--inline-md")}>
-                        <li>
-                            <Button linkProps={routes.home().link}>Page d&apos;accueil</Button>
-                        </li>
-                        <li>
-                            <Button linkProps={routes.contact().link} className={fr.cx("fr-btn--secondary")}>
-                                Nous écrire
-                            </Button>
-                        </li>
-                    </ul>
+                    <ButtonsGroup
+                        buttons={[
+                            {
+                                children: "Page d’accueil",
+                                linkProps: routes.home().link,
+                            },
+                            {
+                                children: "Nous écrire",
+                                linkProps: routes.contact().link,
+                                priority: "secondary",
+                            },
+                        ]}
+                        inlineLayoutWhen="md and up"
+                    />
                 </div>
                 <div className={fr.cx("fr-col-12", "fr-col-md-3", "fr-col-offset-md-1", "fr-px-6w", "fr-px-md-0", "fr-py-0")}>
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
-                        className={"fr-responsive-img fr-artwork"}
+                        className={fr.cx("fr-responsive-img", "fr-artwork")}
                         aria-hidden="true"
                         width="160"
                         height="200"


### PR DESCRIPTION
Dans un layout qui ressemble à celui de la page d'erreur 404, avec un picto cadenas, affiche un message et des actions possibles concernant clés d'accès et permissions.

Issue liée : #653 