### PR TITLE
ci: analyse trivy après build docker

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -29,16 +29,6 @@ jobs:
             - name: Setup Docker buildx
               uses: docker/setup-buildx-action@v3
 
-            # Login against a Docker registry (only if semver tag)
-            # https://github.com/docker/login-action
-            - name: Log into registry ${{ env.REGISTRY }}
-              if: startsWith(github.event.ref, 'refs/tags/v')
-              uses: docker/login-action@v3
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
             # Extract metadata (tags, labels) for Docker
             # https://github.com/docker/metadata-action
             - name: Extract Docker metadata
@@ -47,18 +37,79 @@ jobs:
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-            ## Build and push Docker image with Buildx (push only if semver tag)
             # https://github.com/docker/build-push-action
-            - name: Build and push Docker image
-              id: build-and-push
+            - name: Build Docker image
+              id: build
               uses: docker/build-push-action@v6
               with:
                   context: .
                   file: .docker/Dockerfile
                   pull: true
-                  push: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+                  push: false
+                  load: true
                   target: prod
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
+
+            - name: Run Trivy vulnerability scanner
+              uses: aquasecurity/trivy-action@0.30.0
+              with:
+                  image-ref: ${{ steps.meta.outputs.tags }}
+                  format: "sarif"
+                  output: "trivy-results.sarif"
+
+            - name: Upload Trivy scan results to GitHub Security tab
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: "trivy-results.sarif"
+
+    # push:
+    #     if: startsWith(github.event.ref, 'refs/tags/v')
+    #     runs-on: ubuntu-latest
+    #     permissions:
+    #         contents: read
+    #         packages: write
+    #     steps:
+    #         - name: Checkout repository
+    #           uses: actions/checkout@v4
+
+    #         # Workaround: https://github.com/docker/build-push-action/issues/461
+    #         - name: Setup Docker buildx
+    #           uses: docker/setup-buildx-action@v3
+
+    #         # Login against a Docker registry (only if semver tag)
+    #         # https://github.com/docker/login-action
+    #         - name: Log into registry ${{ env.REGISTRY }}
+    #           if: startsWith(github.event.ref, 'refs/tags/v')
+    #           uses: docker/login-action@v3
+    #           with:
+    #               registry: ${{ env.REGISTRY }}
+    #               username: ${{ github.actor }}
+    #               password: ${{ secrets.GITHUB_TOKEN }}
+
+    #         # Extract metadata (tags, labels) for Docker
+    #         # https://github.com/docker/metadata-action
+    #         - name: Extract Docker metadata
+    #           id: meta
+    #           uses: docker/metadata-action@v5
+    #           with:
+    #               images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    #         - name: Push image to github registry and generate SBOM
+    #           if: startsWith(github.event.ref, 'refs/tags/v')
+    #           uses: docker/build-push-action@v6
+    #           with:
+    #               context: .
+    #               file: .docker/Dockerfile
+    #               pull: true
+    #               push: true
+    #               load: false
+    #               sbom: true
+    #               provenance: mode=max
+    #               target: prod
+    #               tags: ${{ steps.meta.outputs.tags }}
+    #               labels: ${{ steps.meta.outputs.labels }}
+    #               cache-from: type=gha
+    #               cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -65,51 +65,49 @@ jobs:
               with:
                   sarif_file: "trivy-results.sarif"
 
-    # push:
-    #     if: startsWith(github.event.ref, 'refs/tags/v')
-    #     runs-on: ubuntu-latest
-    #     permissions:
-    #         contents: read
-    #         packages: write
-    #     steps:
-    #         - name: Checkout repository
-    #           uses: actions/checkout@v4
+    push:
+        if: startsWith(github.event.ref, 'refs/tags/v')
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-    #         # Workaround: https://github.com/docker/build-push-action/issues/461
-    #         - name: Setup Docker buildx
-    #           uses: docker/setup-buildx-action@v3
+            # Workaround: https://github.com/docker/build-push-action/issues/461
+            - name: Setup Docker buildx
+              uses: docker/setup-buildx-action@v3
 
-    #         # Login against a Docker registry (only if semver tag)
-    #         # https://github.com/docker/login-action
-    #         - name: Log into registry ${{ env.REGISTRY }}
-    #           if: startsWith(github.event.ref, 'refs/tags/v')
-    #           uses: docker/login-action@v3
-    #           with:
-    #               registry: ${{ env.REGISTRY }}
-    #               username: ${{ github.actor }}
-    #               password: ${{ secrets.GITHUB_TOKEN }}
+            # Login against a Docker registry (only if semver tag)
+            # https://github.com/docker/login-action
+            - name: Log into registry ${{ env.REGISTRY }}
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-    #         # Extract metadata (tags, labels) for Docker
-    #         # https://github.com/docker/metadata-action
-    #         - name: Extract Docker metadata
-    #           id: meta
-    #           uses: docker/metadata-action@v5
-    #           with:
-    #               images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            - name: Extract Docker metadata
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-    #         - name: Push image to github registry and generate SBOM
-    #           if: startsWith(github.event.ref, 'refs/tags/v')
-    #           uses: docker/build-push-action@v6
-    #           with:
-    #               context: .
-    #               file: .docker/Dockerfile
-    #               pull: true
-    #               push: true
-    #               load: false
-    #               sbom: true
-    #               provenance: mode=max
-    #               target: prod
-    #               tags: ${{ steps.meta.outputs.tags }}
-    #               labels: ${{ steps.meta.outputs.labels }}
-    #               cache-from: type=gha
-    #               cache-to: type=gha,mode=max
+            - name: Build & Push image to github registry and generate SBOM
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: .docker/Dockerfile
+                  pull: true
+                  push: true
+                  load: false
+                  sbom: true
+                  provenance: mode=max
+                  target: prod
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max


### PR DESCRIPTION
Ajout d'une analyse trivy dans le github action docker-build-push + envoi de résultats dans l'onglet Security (https://github.com/IGNF/cartes.gouv.fr/security/code-scanning)