### PR TITLE
feat: add configurable technical name for config datastore + clear RSS feed cache + manage annexe add

### DIFF
--- a/.env
+++ b/.env
@@ -60,5 +60,6 @@ SANDBOX_PROC_CREATE_RAST_PYR=
 # URL de l'API espace collaboratif
 API_ESPACE_COLLABORATIF_URL=
 
-# Id de la community liee au datastore de configuration
+# Configuration liee au datastore de configuration
 CONFIG_COMMUNITY_ID=
+CONFIG_TECHNICAL_NAME=

--- a/assets/entrepot/api/alerts.ts
+++ b/assets/entrepot/api/alerts.ts
@@ -1,10 +1,10 @@
-import { annexesUrl, communityId } from "@/env";
+import { annexesUrl, configCommunityId, configTechnicalName } from "@/env";
 import { IApiAlert } from "../../@types/alert";
 import { jsonFetch } from "../../modules/jsonFetch";
 
 const annexePath = "/public/alerts.json";
 const fileName = annexePath.substring(annexePath.lastIndexOf("/") + 1);
-const baseUrl = `${annexesUrl}/cartes.gouv.fr-config`;
+const baseUrl = `${annexesUrl}/${configTechnicalName}`;
 
 const get = (otherOptions: RequestInit = {}) => {
     return jsonFetch<IApiAlert[]>(`${baseUrl}${annexePath}`, {
@@ -14,7 +14,7 @@ const get = (otherOptions: RequestInit = {}) => {
 
 export default {
     annexePath,
-    communityId,
+    communityId: configCommunityId,
     fileName,
     get,
 };

--- a/assets/entrepot/api/annexe.ts
+++ b/assets/entrepot/api/annexe.ts
@@ -9,6 +9,15 @@ const getList = (datastoreId: string, otherOptions: RequestInit = {}) => {
     });
 };
 
+const add = (datastoreId: string, path: string, file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("path", path);
+
+    const url = SymfonyRouting.generate("cartesgouvfr_api_annexe_add", { datastoreId });
+    return jsonFetch<Annexe>(url, { method: "POST" }, formData, true, true);
+};
+
 const modify = (datastoreId: string, annexeId: string, data: object) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_annexe_modify", { datastoreId, annexeId });
     return jsonFetch<Annexe>(url, { method: "PATCH" }, data);
@@ -46,6 +55,7 @@ const remove = (datastoreId: string, annexeId: string) => {
 
 export default {
     getList,
+    add,
     modify,
     replaceFile,
     addThumbnail,

--- a/assets/entrepot/pages/config/Alerts.tsx
+++ b/assets/entrepot/pages/config/Alerts.tsx
@@ -89,18 +89,17 @@ const Alerts: FC = () => {
 
     // Update alerts mutation
     const { mutate, isPending } = useMutation<Annexe | undefined, CartesApiException, IAlert[]>({
-        mutationFn: async (alerts) => {
+        mutationFn: (alerts) => {
+            const data = alerts.map((alert) => ({ ...alert, date: alert.date.toISOString() }));
+            const blob = new Blob([JSON.stringify(data)], {
+                type: "application/json",
+            });
+            const file = new File([blob], fileName);
+            queryClient.setQueryData(RQKeys.alerts(), () => data);
             if (annexe?._id) {
-                const data = alerts.map((alert) => ({ ...alert, date: alert.date.toISOString() }));
-                const blob = new Blob([JSON.stringify(data)], {
-                    type: "application/json",
-                });
-                const file = new File([blob], fileName);
-                queryClient.setQueryData(RQKeys.alerts(), () => data);
-                const response = await api.annexe.replaceFile(datastore?._id, annexe?._id, file);
-                return response;
+                return api.annexe.replaceFile(datastore?._id, annexe?._id, file);
             }
-            return Promise.resolve(undefined);
+            return api.annexe.add(datastore?._id, annexePath, file);
         },
         onError: (error) => {
             setNotification({ severity: "error", title: t("alerts_update_error") });
@@ -307,7 +306,7 @@ const Alerts: FC = () => {
                         {...(closable ? { onClose: () => setNotification(null), closable: true } : { closable: false })}
                     />
                 )}
-                <Button disabled={!annexe || isPending} iconId={"fr-icon-add-line"} type="submit">
+                <Button disabled={isPending} iconId={"fr-icon-add-line"} type="submit">
                     {t("save")}
                 </Button>
             </form>

--- a/assets/env.ts
+++ b/assets/env.ts
@@ -2,5 +2,6 @@ const rootDataset = (document.getElementById("root") as HTMLDivElement)?.dataset
 
 export const espaceCoUrl = rootDataset?.["apiEspacecoUrl"] ?? null;
 export const catalogueUrl = rootDataset?.["catalogueUrl"] ?? "/catalogue";
-export const communityId = rootDataset?.["configCommunityId"] ?? null;
+export const configCommunityId = rootDataset?.["configCommunityId"] ?? null;
+export const configTechnicalName = rootDataset?.["configTechnicalName"] ?? null;
 export const annexesUrl = rootDataset?.["annexesUrl"] ?? "https://data.geopf.fr/annexes";

--- a/config/parameters.yaml
+++ b/config/parameters.yaml
@@ -24,6 +24,7 @@ parameters:
 
     config:
         community_id: "%env(resolve:CONFIG_COMMUNITY_ID)%"
+        technical_name: "%env(resolve:CONFIG_TECHNICAL_NAME)%"
 
     api_entrepot_url: "%env(resolve:API_ENTREPOT_URL)%"
     annexes_url: "%env(resolve:ANNEXES_URL)%"

--- a/templates/app.html.twig
+++ b/templates/app.html.twig
@@ -6,6 +6,7 @@
         {% if catalogue_url is defined and catalogue_url is not empty %}data-catalogue-url="{{ catalogue_url }}"{% endif %}
         {% if annexes_url is defined and annexes_url is not empty %}data-annexes-url="{{ annexes_url }}"{% endif %}
         {% if config is defined and config.community_id is defined and config.community_id is not empty %}data-config-community-id="{{ config.community_id }}"{% endif %}
+        {% if config is defined and config.technical_name is defined and config.technical_name is not empty %}data-config-technical-name="{{ config.technical_name }}"{% endif %}
     ></div>
 
     {% if app.user is defined and app.user is not null %}


### PR DESCRIPTION
fix for issue: https://github.com/IGNF/cartes.gouv.fr/issues/736

includes:
* add `CONFIG_TECHNICAL_NAME` for configuring the technical name of the config datastore
* manage creation of alerts.json annex file if it does not exists (when saving alerts on a datastore that does not yet contains an alerts.json annex file)
* Clear RSS cache when updating or creating alerts.json annex file