### PR TITLE
feat: Ajouter la catégorie d'utilisateur au formulaire de contact #773

### DIFF
--- a/assets/@types/app.ts
+++ b/assets/@types/app.ts
@@ -392,3 +392,6 @@ export type GeonetworkMetadataResponse = {
 
 /* Liens dans les composants de type Summary */
 export type SummaryLink = SummaryProps["links"][number];
+
+export const arrUserCategories = ["Individual", "Professional"] as const;
+export type UserCategory = (typeof arrUserCategories)[number];

--- a/assets/@types/espaceco.ts
+++ b/assets/@types/espaceco.ts
@@ -192,7 +192,7 @@ export interface CommunityPatchDTO extends Partial<Omit<CommunityResponseDTO, "l
 
 export const arrPermissionLevel = ["NONE", "VIEW", "EDIT"] as const;
 export type PermissionLevel = (typeof arrPermissionLevel)[number];
-7;
+
 export type PermissionResponseDTO = {
     id: number;
     database: number;

--- a/assets/pages/assistance/contact/Contact.locale.tsx
+++ b/assets/pages/assistance/contact/Contact.locale.tsx
@@ -1,6 +1,7 @@
 import { RegisteredLinkProps } from "@codegouvfr/react-dsfr/link";
 import { declareComponentKeys } from "i18nifty";
 
+import { UserCategory } from "@/@types/app";
 import { Translations } from "../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
@@ -13,10 +14,16 @@ const { i18n } = declareComponentKeys<
     | "form.email_contact_mandatory_error"
     | "form.email_contact_error"
     | "form.lastName"
+    | "form.message_lastName_mandatory"
     | "form.firstName"
+    | "form.message_firstName_mandatory"
+    | "form.category"
+    | { K: "form.category_option"; P: { option: UserCategory }; R: string }
     | "form.organization"
+    | "form.message_organization_mandatory"
     | "form.message"
     | "form.message_placeholder"
+    | "form.message.trimmed_error"
     | { K: "form.message_minlength_error"; P: { min: number }; R: string }
     | { K: "form.message_maxlength_error"; P: { max: number }; R: string }
     | { K: "remaining_characters"; P: { num: number }; R: string }
@@ -45,11 +52,24 @@ export const ContactFrTranslations: Translations<"fr">["Contact"] = {
     "form.email_contact_hint": "Format attendu : nom@domaine.fr",
     "form.email_contact_mandatory_error": "Veuillez saisir une adresse email",
     "form.email_contact_error": "Veuillez saisir une adresse email valide",
-    "form.lastName": "Votre nom (optionnel)",
-    "form.firstName": "Votre prénom (optionnel)",
-    "form.organization": "Votre organisme (optionnel)",
+    "form.lastName": "Votre nom",
+    "form.message_lastName_mandatory": "Le nom est obligatoire",
+    "form.firstName": "Votre prénom",
+    "form.message_firstName_mandatory": "Le prénom est obligatoire",
+    "form.category": "Vous êtes ?",
+    "form.category_option": ({ option }) => {
+        switch (option) {
+            case "Individual":
+                return "Particulier";
+            case "Professional":
+                return "Professionnel";
+        }
+    },
+    "form.organization": "Votre organisme",
+    "form.message_organization_mandatory": "L'organisme est obligatoire",
     "form.message": "Votre demande",
     "form.message_placeholder": "Décrivez votre demande en quelques lignes",
+    "form.message.trimmed_error": "La chaîne de caractères ne doit contenir aucun espace en début et fin",
     "form.message_minlength_error": ({ min }) => `Veuillez saisir une demande d’au moins ${min} caractères.`,
     "form.message_maxlength_error": ({ max }) => `Votre demande ne peut contenir que ${max} caractères.`,
     remaining_characters: ({ num }) => `${num} caractères restants`,
@@ -89,11 +109,17 @@ export const ContactEnTranslations: Translations<"en">["Contact"] = {
     "form.email_contact_hint": "Expected format: name@domain.fr",
     "form.email_contact_mandatory_error": "Enter an email address",
     "form.email_contact_error": "Enter a valid email address",
-    "form.lastName": "Last name (optional)",
-    "form.firstName": "First name (optional)",
-    "form.organization": "Organization (optional)",
+    "form.lastName": "Last name",
+    "form.message_lastName_mandatory": "Last name is mandatory",
+    "form.firstName": "First name",
+    "form.message_firstName_mandatory": "First name is mandatory",
+    "form.category": "You are ?",
+    "form.category_option": ({ option }) => `${option}`,
+    "form.organization": "Organization",
+    "form.message_organization_mandatory": "Organization is mandatory",
     "form.message": "Message",
     "form.message_placeholder": "Describe your request in a few lines",
+    "form.message.trimmed_error": "The character string must not contain any spaces at the beginning and end",
     "form.message_minlength_error": ({ min }) => `Message must be at least ${min} characters.`,
     "form.message_maxlength_error": ({ max }) => `Message cannot exceed ${max} characters.`,
     remaining_characters: ({ num }) => `${num} characters remaining`,

--- a/assets/pages/assistance/contact/Contact.tsx
+++ b/assets/pages/assistance/contact/Contact.tsx
@@ -5,34 +5,51 @@ import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { TranslationFunction } from "i18nifty/typeUtils/TranslationFunction";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import * as yup from "yup";
 
+import { arrUserCategories } from "@/@types/app";
+import Main from "../../../components/Layout/Main";
 import LoadingIcon from "../../../components/Utils/LoadingIcon";
 import Wait from "../../../components/Utils/Wait";
+import { useAlert } from "../../../hooks/useAlert";
 import { useTranslation } from "../../../i18n/i18n";
 import { ComponentKey } from "../../../i18n/types";
 import SymfonyRouting from "../../../modules/Routing";
 import { jsonFetch } from "../../../modules/jsonFetch";
 import { routes } from "../../../router/router";
+import { useAlertStore } from "../../../stores/AlertStore";
 import { useAuthStore } from "../../../stores/AuthStore";
 import { regex } from "../../../utils";
-import Main from "../../../components/Layout/Main";
-import { useAlertStore } from "../../../stores/AlertStore";
-import { useAlert } from "../../../hooks/useAlert";
 
+import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
 import "../../../sass/pages/nous_ecrire.scss";
 
 const charRange = [10, 8000];
+const noOrganization = "SO";
+
+type ContactForm = {
+    email_contact: string;
+    last_name: string;
+    first_name: string;
+    category: string;
+    organization: string;
+    importance?: number;
+    message?: string;
+};
 
 const schema = (t: TranslationFunction<"Contact", ComponentKey>) =>
     yup
         .object({
             email_contact: yup.string().matches(regex.email, t("form.email_contact_error")).required(t("form.email_contact_mandatory_error")),
-            last_name: yup.string(),
-            first_name: yup.string(),
-            organization: yup.string(),
+            last_name: yup.string().trim(t("form.message.trimmed_error")).strict(true).required(t("form.message_lastName_mandatory")),
+            first_name: yup.string().trim(t("form.message.trimmed_error")).strict(true).required(t("form.message_firstName_mandatory")),
+            category: yup
+                .string()
+                .oneOf(arrUserCategories.map((c) => t("form.category_option", { option: c })))
+                .required(),
+            organization: yup.string().trim(t("form.message.trimmed_error")).strict(true).required(t("form.message_organization_mandatory")),
             importance: yup.number(),
             message: yup
                 .string()
@@ -50,23 +67,46 @@ const Contact = () => {
     const [isSending, setIsSending] = useState(false);
     const [error, setError] = useState(null);
 
+    const defaultCategory = t("form.category_option", { option: "Professional" });
+
     const {
         register,
         handleSubmit,
         formState: { errors },
         getValues: getFormValues,
+        setValue: setFormValue,
         watch,
-    } = useForm({ resolver: yupResolver(schema(t)) });
+    } = useForm<ContactForm>({
+        defaultValues: {
+            email_contact: user?.email,
+            last_name: user?.last_name ?? "",
+            first_name: user?.first_name ?? "",
+            category: defaultCategory,
+            organization: "",
+        },
+        resolver: yupResolver(schema(t)),
+    });
 
     const message = watch("message") ?? "";
+    const category = watch("category");
+
+    useEffect(() => {
+        if (category !== defaultCategory) {
+            setFormValue("organization", noOrganization);
+        } else setFormValue("organization", "");
+    }, [category, defaultCategory, setFormValue]);
 
     const onSubmit = () => {
         setError(null);
         setIsSending(true);
 
         const url = SymfonyRouting.generate("cartesgouvfr_contact_contact_us");
+        const values = getFormValues();
+        if (values.category !== defaultCategory) {
+            values.organization = "SO";
+        }
 
-        jsonFetch<{ success: boolean }>(url, { method: "POST" }, getFormValues())
+        jsonFetch<{ success: boolean }>(url, { method: "POST" }, values)
             .then((response) => {
                 if (response?.success === true) {
                     routes.contact_confirmation().push();
@@ -97,7 +137,6 @@ const Contact = () => {
                         hintText={t("form.email_contact_hint")}
                         nativeInputProps={{
                             ...register("email_contact"),
-                            defaultValue: user?.email,
                             readOnly: user ? true : false,
                             autoComplete: "email",
                         }}
@@ -106,7 +145,6 @@ const Contact = () => {
                         label={t("form.lastName")}
                         nativeInputProps={{
                             ...register("last_name"),
-                            defaultValue: user?.last_name ?? "",
                             readOnly: user?.last_name ? true : false,
                             autoComplete: "family-name",
                         }}
@@ -115,13 +153,26 @@ const Contact = () => {
                         label={t("form.firstName")}
                         nativeInputProps={{
                             ...register("first_name"),
-                            defaultValue: user?.first_name ?? "",
                             readOnly: user?.first_name ? true : false,
                             autoComplete: "given-name",
                         }}
                     />
+                    <RadioButtons
+                        legend={t("form.category")}
+                        options={arrUserCategories.map((c) => ({
+                            label: t("form.category_option", { option: c }),
+                            nativeInputProps: {
+                                ...register("category"),
+                                value: t("form.category_option", { option: c }),
+                            },
+                        }))}
+                        orientation={"horizontal"}
+                    />
                     <Input
+                        className={category !== defaultCategory ? fr.cx("fr-hidden") : ""}
                         label={t("form.organization")}
+                        state={errors.organization ? "error" : "default"}
+                        stateRelatedMessage={errors?.organization?.message}
                         nativeInputProps={{
                             ...register("organization"),
                             autoComplete: "organization",

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -67,6 +67,8 @@ class ContactController extends AbstractController
                 'userEmail' => $userEmail,
                 'firstName' => $data['first_name'],
                 'lastName' => $data['last_name'],
+                'category' => $data['category'],
+                'organization' => $data['organization'],
                 'sendDate' => $now,
                 'message' => $message,
             ];

--- a/templates/Mailer/contact.html.twig
+++ b/templates/Mailer/contact.html.twig
@@ -19,6 +19,14 @@
             <p><strong>{{ 'contact.email_support.user_id'|trans }} : </strong>{{ userId }}</p>
         {% endif %}
 
+        <p>
+            <strong>{{ 'contact.email_support.category'|trans }} : </strong>{{ category }}
+        </p>
+
+        <p>
+            <strong>{{ 'contact.email_support.organization'|trans }} : </strong>{{ organization }}
+        </p>
+
         <p><strong>{{ 'contact.email_support.date'|trans }} : </strong>{{ sendDate|date('d-m-Y H:i', 'Europe/Paris') }}</p>
 
         <p>

--- a/translations/cartesgouvfr.fr.yml
+++ b/translations/cartesgouvfr.fr.yml
@@ -19,6 +19,8 @@ contact:
         user_email: "Adresse mail de l’utilisateur"
         last_name: "Nom de l’utilisateur"
         first_name: "Prénom de l’utilisateur"
+        category: "Catégorie"
+        organization: "Organisme"
         date: "Date d’envoi"
         message: "Corps du message"
         not_specified: "Non renseigné"


### PR DESCRIPTION
La catégorie (Professionnel ou Particulier) a été ajouté au formulaire de contact

Le comportement est le suivant :
Si on choisit Particulier organisme sera caché et aura SO comme valeur