### PR TITLE
chore: add robots.txt (#798)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
Sans instruction de pages publiques à ne pas indexer (toutes briques confondues)

Issue concernée : #798 