### PR TITLE
fix: mention accès restreint en description (#804)

### DIFF
--- a/templates/metadata/metadata_dataset_iso.xml.twig
+++ b/templates/metadata/metadata_dataset_iso.xml.twig
@@ -269,7 +269,7 @@
                                             <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">other</gmx:Anchor>
                                         </gmd:applicationProfile>
                                         <gmd:description>
-                                            <gmx:Anchor xlink:href="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode_restricted">Le service associé à cette donnée est en accès restreint, veuillez contacter le producteur de la donnée pour en obtenir l'accès</gmx:Anchor>
+                                            <gmx:Anchor xlink:href="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode_restricted">{{ layer.name }} - Accès restreint</gmx:Anchor>
                                         </gmd:description>
                                     {% endif %}
                                 </gmd:CI_OnlineResource>


### PR DESCRIPTION

<img width="518" height="186" alt="image" src="https://github.com/user-attachments/assets/b12d485c-2507-4823-ad74-5a6cef6546e3" />

Issue concernée : #804 