### PR TITLE
feat: refonte interface 'mes cles' #746

### DIFF
--- a/assets/components/Utils/TextCopyToClipboard.tsx
+++ b/assets/components/Utils/TextCopyToClipboard.tsx
@@ -15,11 +15,24 @@ export interface TextCopyToClipboardProps extends InputProps.Common {
     text: string;
     textArea?: boolean;
     title?: string;
+    copyLabel?: string;
+    copiedLabel?: string;
 }
 
 const TextCopyToClipboard: FC<TextCopyToClipboardProps> = (props) => {
     const { t } = useTranslation("Common");
-    const { disabled = false, label, nativeInputProps, nativeTextAreaProps, text, textArea, title = t("copy_to_clipboard"), ...inputProps } = props;
+    const {
+        disabled = false,
+        label,
+        nativeInputProps,
+        nativeTextAreaProps,
+        text,
+        textArea,
+        title = t("copy_to_clipboard"),
+        copyLabel = t("copy"),
+        copiedLabel = t("alert_copied"),
+        ...inputProps
+    } = props;
     const { classes } = useStyles({ disabled });
     const { copied, copy } = useCopyToClipboard();
 
@@ -55,7 +68,7 @@ const TextCopyToClipboard: FC<TextCopyToClipboardProps> = (props) => {
                         title={title}
                         onClick={() => copy(text)}
                     >
-                        <span>{copied ? t("alert_copied") : t("copy")}</span>
+                        <span>{copied ? copiedLabel : copyLabel}</span>
                     </Button>
                 </div>
             }

--- a/assets/entrepot/pages/users/access-keys/MyAccessKeys.locale.tsx
+++ b/assets/entrepot/pages/users/access-keys/MyAccessKeys.locale.tsx
@@ -1,17 +1,8 @@
-import { fr } from "@codegouvfr/react-dsfr";
 import { declareComponentKeys } from "i18nifty";
 
 import { Translations } from "../../../../i18n/types";
 
-const { i18n } = declareComponentKeys<
-    | "title"
-    | "my_access_keys"
-    | "add_access_keys"
-    | "my_permissions"
-    | { K: "explain_my_keys"; R: JSX.Element }
-    | { K: "explain_my_permissions"; R: JSX.Element }
-    | "burger_menu"
->()("MyAccessKeys");
+const { i18n } = declareComponentKeys<"title" | "my_access_keys" | "add_access_keys" | "my_permissions" | "burger_menu">()("MyAccessKeys");
 export type I18n = typeof i18n;
 
 export const MyAccessKeysFrTranslations: Translations<"fr">["MyAccessKeys"] = {
@@ -19,26 +10,6 @@ export const MyAccessKeysFrTranslations: Translations<"fr">["MyAccessKeys"] = {
     my_access_keys: "Mes clés d’accès",
     add_access_keys: "Créer une clé d’accès",
     my_permissions: "Mes permissions",
-    explain_my_keys: (
-        <>
-            <p>{"Les données publiques sont par défaut disponibles sans création de clé d'accès."}</p>
-            <p className={fr.cx("fr-mb-6v")}>
-                {
-                    "Sur cette page vous pouvez créer des clés d'accès et les utiliser dans vos outils (SIG, site internet, etc.) pour exploiter les permissions qui vous ont été accordées par les producteurs de données."
-                }
-            </p>
-        </>
-    ),
-    explain_my_permissions: (
-        <>
-            <p>{"Sur cette page vous pouvez consulter les permissions qui vous ont été octroyées par les producteurs de données."}</p>
-            <p className={fr.cx("fr-mb-6v")}>
-                {
-                    "Chaque permission ne vous permet d'accéder qu'aux services listés et a une date d'expiration. Vous ne pouvez pas modifier vos permissions, c'est le producteur de la donnée uniquement qui peut la modifier, ajouter de nouveaux services ou prolonger sa durée de validité."
-                }
-            </p>
-        </>
-    ),
     burger_menu: "Dans cette rubrique",
 };
 
@@ -47,7 +18,5 @@ export const MyAccessKeysEnTranslations: Translations<"en">["MyAccessKeys"] = {
     my_access_keys: "My keys",
     add_access_keys: "Create access key",
     my_permissions: "My permissions",
-    explain_my_keys: undefined,
-    explain_my_permissions: undefined,
     burger_menu: "In this section",
 };

--- a/assets/entrepot/pages/users/access-keys/MyAccessKeys.locale.tsx
+++ b/assets/entrepot/pages/users/access-keys/MyAccessKeys.locale.tsx
@@ -4,12 +4,20 @@ import { declareComponentKeys } from "i18nifty";
 import { Translations } from "../../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
-    "my_access_keys" | "my_permissions" | { K: "explain_my_keys"; R: JSX.Element } | { K: "explain_my_permissions"; R: JSX.Element } | "burger_menu"
+    | "title"
+    | "my_access_keys"
+    | "add_access_keys"
+    | "my_permissions"
+    | { K: "explain_my_keys"; R: JSX.Element }
+    | { K: "explain_my_permissions"; R: JSX.Element }
+    | "burger_menu"
 >()("MyAccessKeys");
 export type I18n = typeof i18n;
 
 export const MyAccessKeysFrTranslations: Translations<"fr">["MyAccessKeys"] = {
+    title: "Clés d’accès",
     my_access_keys: "Mes clés d’accès",
+    add_access_keys: "Créer une clé d’accès",
     my_permissions: "Mes permissions",
     explain_my_keys: (
         <>
@@ -35,7 +43,9 @@ export const MyAccessKeysFrTranslations: Translations<"fr">["MyAccessKeys"] = {
 };
 
 export const MyAccessKeysEnTranslations: Translations<"en">["MyAccessKeys"] = {
+    title: "Access keys",
     my_access_keys: "My keys",
+    add_access_keys: "Create access key",
     my_permissions: "My permissions",
     explain_my_keys: undefined,
     explain_my_permissions: undefined,

--- a/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
+++ b/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
@@ -1,10 +1,10 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { SideMenu } from "@codegouvfr/react-dsfr/SideMenu";
 import { useQuery } from "@tanstack/react-query";
-import { FC } from "react";
+import { FC, useMemo } from "react";
 
 import { UserKeyDetailedWithAccessesResponseDto } from "../../../../@types/app";
-import { PermissionWithOfferingsDetailsResponseDto } from "../../../../@types/entrepot";
+import { PermissionWithOfferingsDetailsResponseDto, UserKeyDetailsResponseDtoUserKeyInfoDtoTypeEnum } from "../../../../@types/entrepot";
 import LoadingText from "../../../../components/Utils/LoadingText";
 import { getTranslation } from "../../../../i18n/i18n";
 import RQKeys from "../../../../modules/entrepot/RQKeys";
@@ -13,6 +13,8 @@ import UserKeysListTab from "../keys/UserKeysListTab/UserKeysListTab";
 import PermissionsListTab from "../permissions/PermissionsListTab";
 import { routes } from "../../../../router/router";
 import Main from "../../../../components/Layout/Main";
+import Button from "@codegouvfr/react-dsfr/Button";
+import "../../../../sass/components/buttons.scss";
 
 type MyAccessKeysProps = {
     activeTab: string;
@@ -39,13 +41,35 @@ const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
         staleTime: 30000,
     });
 
+    /* Y-a-t-il deja une cle OAUTH2 */
+    const hasOauth2 = useMemo(() => {
+        const f = keys?.find((key) => key.type === UserKeyDetailsResponseDtoUserKeyInfoDtoTypeEnum.OAUTH2);
+        return !!f;
+    }, [keys]);
+
+    /* l'utilisateur a-t-il des permissions */
+    const hasPermissions = useMemo(() => {
+        return permissions !== undefined && permissions.length > 0;
+    }, [permissions]);
+
+    /* Ces permissions sont-elles toutes only_oauth a true */
+    const permissionsAreAllOnlyOauth = useMemo(() => {
+        const oauths = permissions?.filter((permission) => permission.only_oauth) ?? [];
+        return oauths.length === permissions?.length;
+    }, [permissions]);
+
+    const canAdd = useMemo(() => {
+        return hasPermissions && !(hasOauth2 && permissionsAreAllOnlyOauth);
+    }, [hasPermissions, hasOauth2, permissionsAreAllOnlyOauth]);
+
     return (
         <Main title={documentTitle}>
+            <h1>{t("title")}</h1>
             {isLoadingKeys || isLoadingPermissions ? (
                 <LoadingText />
             ) : (
                 <div className={fr.cx("fr-grid-row")}>
-                    <div className={fr.cx("fr-col-12", "fr-col-md-4")}>
+                    <div className={fr.cx("fr-col-12", "fr-col-md-4", "fr-mb-5v")}>
                         <SideMenu
                             align="left"
                             burgerMenuButtonText={t("burger_menu")}
@@ -67,13 +91,25 @@ const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
                     <div className={fr.cx("fr-col-12", "fr-col-md-8")}>
                         {tab === "keys" ? (
                             <>
-                                <h1>{t("my_access_keys")}</h1>
-                                {t("explain_my_keys")}
+                                <div className={fr.cx("fr-grid-row", "fr-grid-row--middle")}>
+                                    <div className={fr.cx("fr-col-12", "fr-col-sm-7")}>
+                                        <h2 className={fr.cx("fr-m-0")}>{t("my_access_keys")}</h2>
+                                    </div>
+                                    <div className={`frx-btns-group--right-sm frx-mt-sm-0 ${fr.cx("fr-col-12", "fr-col-sm-5", "fr-mt-5v")}`}>
+                                        <Button
+                                            iconId="fr-icon-arrow-right-s-line"
+                                            iconPosition="right"
+                                            {...(canAdd ? { linkProps: routes.user_key_add().link } : { disabled: true })}
+                                        >
+                                            {t("add_access_keys")}
+                                        </Button>
+                                    </div>
+                                </div>
                                 <UserKeysListTab keys={keys} permissions={permissions} />
                             </>
                         ) : (
                             <>
-                                <h1>{t("my_permissions")}</h1>
+                                <h2>{t("my_permissions")}</h2>
                                 {t("explain_my_permissions")}
                                 <PermissionsListTab permissions={permissions} />
                             </>

--- a/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
+++ b/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
@@ -73,6 +73,7 @@ const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
                         <SideMenu
                             align="left"
                             burgerMenuButtonText={t("burger_menu")}
+                            className={fr.cx("fr-sidemenu--sticky-full-height")}
                             items={[
                                 {
                                     isActive: tab === "keys",

--- a/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
+++ b/assets/entrepot/pages/users/access-keys/MyAccessKeys.tsx
@@ -15,6 +15,7 @@ import { routes } from "../../../../router/router";
 import Main from "../../../../components/Layout/Main";
 import Button from "@codegouvfr/react-dsfr/Button";
 import "../../../../sass/components/buttons.scss";
+import { useAuthStore } from "@/stores/AuthStore";
 
 type MyAccessKeysProps = {
     activeTab: string;
@@ -23,6 +24,8 @@ type MyAccessKeysProps = {
 const { t } = getTranslation("MyAccessKeys");
 
 const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
+    const user = useAuthStore((state) => state.user);
+
     const tab = activeTab;
 
     const documentTitle = tab === "keys" ? t("my_access_keys") : t("my_permissions");
@@ -59,8 +62,9 @@ const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
     }, [permissions]);
 
     const canAdd = useMemo(() => {
-        return hasPermissions && !(hasOauth2 && permissionsAreAllOnlyOauth);
-    }, [hasPermissions, hasOauth2, permissionsAreAllOnlyOauth]);
+        const hasReachedQuota = (user?.keys_use ?? 0) >= (user?.keys_quota ?? Infinity);
+        return hasPermissions && !(hasOauth2 && permissionsAreAllOnlyOauth) && !hasReachedQuota;
+    }, [hasPermissions, hasOauth2, permissionsAreAllOnlyOauth, user?.keys_use, user?.keys_quota]);
 
     return (
         <Main title={documentTitle}>
@@ -111,7 +115,6 @@ const MyAccessKeys: FC<MyAccessKeysProps> = ({ activeTab }) => {
                         ) : (
                             <>
                                 <h2>{t("my_permissions")}</h2>
-                                {t("explain_my_permissions")}
                                 <PermissionsListTab permissions={permissions} />
                             </>
                         )}

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeyLink.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeyLink.tsx
@@ -29,9 +29,11 @@ const UserKeyLink: FC<UserKeyLinkProps> = ({ permissionId, hash, offeringId }) =
         const wmtsUrl = offering.urls?.find((urlObj) => urlObj.type === "WMTS")?.url;
         const tmsUrl = offering.urls?.find((urlObj) => urlObj.type === "TMS")?.url;
 
-        const wmtsCapabilitiesUrl = wmtsUrl ? `${wmtsUrl.split("?")[0]}?service=WMTS&version=1.0.0&request=GetCapabilities&apikey=${hash}` : null;
+        const wmtsCapabilitiesUrl = wmtsUrl
+            ? `${wmtsUrl.split("?")[0]}?service=WMTS&version=1.0.0&request=GetCapabilities${hash ? `&apikey=${hash}` : ""}`
+            : null;
 
-        const tmsCapabilitiesUrl = tmsUrl ? `${tmsUrl.split("/1.0.0/")[0]}/1.0.0/?apikey=${hash}` : null;
+        const tmsCapabilitiesUrl = tmsUrl ? `${tmsUrl.split("/1.0.0/")[0]}/1.0.0/${hash ? `?apikey=${hash}` : ""}` : null;
 
         return (
             <div className={fr.cx("fr-mb-3v")}>
@@ -48,6 +50,7 @@ const UserKeyLink: FC<UserKeyLinkProps> = ({ permissionId, hash, offeringId }) =
                         className={fr.cx("fr-mb-4v")}
                         label="WMTS"
                         text={wmtsCapabilitiesUrl}
+                        copyLabel={"Copier l'URL"}
                     />
                 )}
                 {tmsCapabilitiesUrl && (
@@ -62,6 +65,7 @@ const UserKeyLink: FC<UserKeyLinkProps> = ({ permissionId, hash, offeringId }) =
                         }
                         label="TMS"
                         text={tmsCapabilitiesUrl}
+                        copyLabel={"Copier l'URL"}
                     />
                 )}
             </div>
@@ -91,6 +95,7 @@ const UserKeyLink: FC<UserKeyLinkProps> = ({ permissionId, hash, offeringId }) =
                 className={fr.cx("fr-mb-4v")}
                 label={offering?.type}
                 text={capabilitiesUrl}
+                copyLabel={"Copier l'URL"}
             />
         );
     }

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
@@ -44,7 +44,7 @@ export const UserKeysListTabFrTranslations: Translations<"fr">["UserKeysListTab"
     ),
     consult_documentation: "Consulter la documentation",
     sorting: "Tri",
-    type_sorting: "Filtrer par flux",
+    type_sorting: "Filtrer par type",
     key_limit: "Le nombre maximal de clés est de ",
     alphabetical_order: "Ordre alphabétique de A à Z",
     reverse_alphabetical_order: "Ordre alphabétique de Z à A",

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
@@ -7,6 +7,11 @@ const { i18n } = declareComponentKeys<
     | "no_keys"
     | { K: "explain_no_keys"; R: JSX.Element }
     | "consult_documentation"
+    | "sorting"
+    | "type_sorting"
+    | "key_limit"
+    | "alphabetical_order"
+    | "reverse_alphabetical_order"
     | "active_keys"
     | "ip_filtering"
     | "user_agent"
@@ -34,10 +39,15 @@ export const UserKeysListTabFrTranslations: Translations<"fr">["UserKeysListTab"
                     "Créer vos clés d’accès et utiliser-les dans vos outils (SIG, site internet, etc.) pour exploiter les permissions qui vous ont été accordées par les producteurs de données."
                 }
             </p>
-            <p className={fr.cx("fr-mb-6v")}>{"* Les données publiques sont disponibles sans création de clé d'accès."}</p>
+            <p>{"* Les données publiques sont disponibles sans création de clé d’accès."}</p>
         </>
     ),
     consult_documentation: "Consulter la documentation",
+    sorting: "Tri",
+    type_sorting: "Filtrer par flux",
+    key_limit: "Le nombre maximal de clés est de ",
+    alphabetical_order: "Ordre alphabétique de A à Z",
+    reverse_alphabetical_order: "Ordre alphabétique de Z à A",
     active_keys: "Clés actives",
     ip_filtering: "Filtrage par IP",
     user_agent: "User agent",
@@ -65,6 +75,11 @@ export const UserKeysListTabEnTranslations: Translations<"en">["UserKeysListTab"
         </>
     ),
     consult_documentation: "Consult the documentation",
+    sorting: "Sorting",
+    type_sorting: undefined,
+    key_limit: "The maximum number of keys is ",
+    alphabetical_order: "Alphabetical order from A to Z",
+    reverse_alphabetical_order: "Alphabetical order from Z to A",
     active_keys: "Active keys",
     ip_filtering: "IP filtering",
     user_agent: "User agent",

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
@@ -15,11 +15,9 @@ const { i18n } = declareComponentKeys<
     | "hash"
     | "unavailable"
     | "hash_value_copied"
-    | "wfs_services"
-    | "wms_raster_services"
-    | "wms_vector_services"
-    | "wmts_tms_services"
-    | "no_services"
+    | "available_services"
+    | "no_services_status"
+    | "no_services_hint"
     | "add"
     | "modify"
     | "remove"
@@ -48,11 +46,10 @@ export const UserKeysListTabFrTranslations: Translations<"fr">["UserKeysListTab"
     hash: "Hash",
     unavailable: "Indisponible",
     hash_value_copied: "Valeur du hash copiée",
-    wfs_services: "Services WFS",
-    wms_raster_services: "Services WMS-Raster",
-    wms_vector_services: "Services WMS-Vecteur",
-    wmts_tms_services: "Services WMTS-TMS",
-    no_services: "Cette clé n'a accès à aucun service",
+    available_services: "Services disponibles",
+    no_services_status: "Indisponible",
+    no_services_hint:
+        "Les services associés à cette clé ont été supprimés ou la permission qui vous y donnait accès n'est plus valable. Vous pouvez supprimer cette clé ou la modifier pour l'associer à d'autres services.",
     add: "Créer une clé d’accès",
     modify: "Modifier la clé",
     remove: "Supprimer la clé",
@@ -76,11 +73,10 @@ export const UserKeysListTabEnTranslations: Translations<"en">["UserKeysListTab"
     hash: "Hash",
     unavailable: "Unavailable",
     hash_value_copied: "Hash value copied",
-    wfs_services: "WFS services",
-    wms_raster_services: "WMS-Raster services",
-    wms_vector_services: "WMS-Vector services",
-    wmts_tms_services: "WMTS-TMS services",
-    no_services: "This key does not have access to any services",
+    available_services: "Available services",
+    no_services_status: "Unavailable",
+    no_services_hint:
+        "The services associated with this key have been deleted or the permission that gave you access to them is no longer valid. You can delete this key or modify it to associate it with other services.",
     add: "Create access key",
     modify: "Modify key",
     remove: "Remove key",

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.locale.tsx
@@ -1,14 +1,24 @@
+import { fr } from "@codegouvfr/react-dsfr";
 import { declareComponentKeys } from "i18nifty";
 
 import { Translations } from "../../../../../i18n/types";
 
 const { i18n } = declareComponentKeys<
     | "no_keys"
+    | { K: "explain_no_keys"; R: JSX.Element }
+    | "consult_documentation"
+    | "active_keys"
+    | "ip_filtering"
+    | "user_agent"
+    | "referer"
     | "no_permission_warning"
-    | "hash_value"
+    | "hash"
     | "unavailable"
     | "hash_value_copied"
-    | "services"
+    | "wfs_services"
+    | "wms_raster_services"
+    | "wms_vector_services"
+    | "wmts_tms_services"
     | "no_services"
     | "add"
     | "modify"
@@ -18,12 +28,30 @@ const { i18n } = declareComponentKeys<
 export type I18n = typeof i18n;
 
 export const UserKeysListTabFrTranslations: Translations<"fr">["UserKeysListTab"] = {
-    no_keys: "Vous n'avez aucune clé d’accès",
+    no_keys: "Vous n’avez pas de clés d’accès.",
+    explain_no_keys: (
+        <>
+            <p>
+                {
+                    "Créer vos clés d’accès et utiliser-les dans vos outils (SIG, site internet, etc.) pour exploiter les permissions qui vous ont été accordées par les producteurs de données."
+                }
+            </p>
+            <p className={fr.cx("fr-mb-6v")}>{"* Les données publiques sont disponibles sans création de clé d'accès."}</p>
+        </>
+    ),
+    consult_documentation: "Consulter la documentation",
+    active_keys: "Clés actives",
+    ip_filtering: "Filtrage par IP",
+    user_agent: "User agent",
+    referer: "Referer",
     no_permission_warning: "Vous n'avez aucune permission, il n'est pas possible d’ajouter une clé",
-    hash_value: "Valeur du hash",
+    hash: "Hash",
     unavailable: "Indisponible",
     hash_value_copied: "Valeur du hash copiée",
-    services: "Services accessibles",
+    wfs_services: "Services WFS",
+    wms_raster_services: "Services WMS-Raster",
+    wms_vector_services: "Services WMS-Vecteur",
+    wmts_tms_services: "Services WMTS-TMS",
     no_services: "Cette clé n'a accès à aucun service",
     add: "Créer une clé d’accès",
     modify: "Modifier la clé",
@@ -32,12 +60,26 @@ export const UserKeysListTabFrTranslations: Translations<"fr">["UserKeysListTab"
 };
 
 export const UserKeysListTabEnTranslations: Translations<"en">["UserKeysListTab"] = {
-    no_keys: "You don't have any access keys",
+    no_keys: "You don't have access keys",
+    explain_no_keys: (
+        <>
+            <p>{"Create your access keys and use them in your tools (GIS, website, etc.) to utilise the permissions granted to you by the data producers."}</p>
+            <p className={fr.cx("fr-mb-6v")}>{"* Public data is available without creating an access key."}</p>
+        </>
+    ),
+    consult_documentation: "Consult the documentation",
+    active_keys: "Active keys",
+    ip_filtering: "IP filtering",
+    user_agent: "User agent",
+    referer: "Referer",
     no_permission_warning: "You have no permissions, it is not possible to add a key",
-    hash_value: "Hash value",
+    hash: "Hash",
     unavailable: "Unavailable",
     hash_value_copied: "Hash value copied",
-    services: "Accessible services",
+    wfs_services: "WFS services",
+    wms_raster_services: "WMS-Raster services",
+    wms_vector_services: "WMS-Vector services",
+    wmts_tms_services: "WMTS-TMS services",
     no_services: "This key does not have access to any services",
     add: "Create access key",
     modify: "Modify key",

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -74,19 +74,15 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
 
     if (!keys) return null;
 
-    const normalizeType = (type: string) => {
-        if (type === "WMTS-RASTER") return "WMTS-RASTER";
-        if (type === "WMTS-VECTOR") return "WMTS-VECTOR";
-        if (type === "WMTS-TMS") return "WMTS_TMS";
-        if (type === "WFS") return "WFS";
-        return type;
-    };
+    const availableTypes = Array.from(new Set((keys ?? []).flatMap((key) => (key.accesses ?? []).map((access) => access.offering.type)))).sort((a, b) =>
+        a.localeCompare(b, "fr", { sensitivity: "base" })
+    );
 
     const filteredAndSortedKeys = [...(keys ?? [])]
         .filter((key) => {
             if (!fluxValue) return true;
             const services = key.accesses ?? [];
-            return services.some((access) => normalizeType(access.offering.type) === fluxValue);
+            return services.some((access) => access.offering.type === fluxValue);
         })
         .sort((a, b) => {
             switch (sortValue) {
@@ -184,10 +180,11 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                 <option value="" disabled hidden>
                                     {tCommon("select_option")}
                                 </option>
-                                <option value="WMS-RASTER">WMS-RASTER</option>
-                                <option value="WMS-VECTOR">WMS-VECTOR</option>
-                                <option value="WMTS_TMS">WMTS / TMS</option>
-                                <option value="WFS">WFS</option>
+                                {availableTypes.map((type) => (
+                                    <option key={type} value={type}>
+                                        {type}
+                                    </option>
+                                ))}
                             </Select>
                         </div>
                     )}

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -75,7 +75,8 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
     if (!keys) return null;
 
     const normalizeType = (type: string) => {
-        if (type.startsWith("WMS")) return "WMS";
+        if (type === "WMTS-RASTER") return "WMTS-RASTER";
+        if (type === "WMTS-VECTOR") return "WMTS-VECTOR";
         if (type === "WMTS-TMS") return "WMTS_TMS";
         if (type === "WFS") return "WFS";
         return type;
@@ -183,7 +184,8 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                 <option value="" disabled hidden>
                                     {tCommon("select_option")}
                                 </option>
-                                <option value="WMS">WMS</option>
+                                <option value="WMS-RASTER">WMS-RASTER</option>
+                                <option value="WMS-VECTOR">WMS-VECTOR</option>
                                 <option value="WMTS_TMS">WMTS / TMS</option>
                                 <option value="WFS">WFS</option>
                             </Select>

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -269,7 +269,6 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                     {accessKey.accesses !== undefined && accessKey.accesses.length !== 0 ? (
                                         <>
                                             {Object.entries(groupedServices).map(([type, services], typeIndex) => {
-                                                console.log(type);
                                                 return (
                                                     <div key={type} className={fr.cx("fr-mb-5v")}>
                                                         {typeIndex >= 1 ? <hr /> : null}

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -117,7 +117,7 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                     />
                     <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
                         <Tooltip title="Le nombre maximal de clés par utilisateur est de 10" />
-                        <h6 className={fr.cx("fr-mt-6v", "fr-mx-1w")}>{t("active_keys")}</h6>
+                        <h3 className={fr.cx("fr-mt-6v", "fr-mx-1w")}>{t("active_keys")}</h3>
                         <Badge noIcon={true} severity={"info"}>
                             {keys.length}/10
                         </Badge>
@@ -158,75 +158,65 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                     className={fr.cx("fr-mb-5v", "fr-px-6v", "fr-py-3w")}
                                     style={{ border: "1px solid", borderColor: fr.colors.decisions.border.default.grey.default }}
                                 >
+                                    <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                                        <div className={fr.cx("fr-col-12", "fr-col-sm-9", "fr-grid-row", "fr-grid-row--middle")}>
+                                            <h4
+                                                style={{
+                                                    overflow: "hidden",
+                                                    textOverflow: "ellipsis",
+                                                    whiteSpace: "nowrap",
+                                                    display: "inline-block",
+                                                    maxWidth: "calc(100% - 5.5rem)",
+                                                }}
+                                                className={fr.cx("fr-mr-1w")}
+                                            >
+                                                {accessKey.name}
+                                            </h4>
+                                            {accessKey.type && (
+                                                <Badge className={fr.cx("fr-mb-6v")} noIcon={true} severity={"info"}>
+                                                    {accessKey.type}
+                                                </Badge>
+                                            )}
+                                        </div>
+
+                                        <div className={`frx-flex-end-sm ${fr.cx("fr-col-12", "fr-col-sm-3", "fr-mb-6v")}`}>
+                                            <Button
+                                                title={tCommon("modify")}
+                                                priority="primary"
+                                                iconId="fr-icon-edit-line"
+                                                size="small"
+                                                onClick={() => {
+                                                    routes.user_key_edit({ keyId: accessKey._id }).push();
+                                                }}
+                                            />
+                                            <Button
+                                                title={tCommon("delete")}
+                                                className={fr.cx("fr-ml-4v")}
+                                                priority="secondary"
+                                                iconId="fr-icon-delete-line"
+                                                size="small"
+                                                onClick={() => {
+                                                    setCurrentKey(accessKey._id);
+                                                    ConfirmDialogModal.open();
+                                                }}
+                                            />
+                                        </div>
+                                    </div>
+
                                     {accessKey.accesses !== undefined && accessKey.accesses.length !== 0 ? (
                                         <>
-                                            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
-                                                <div className={fr.cx("fr-col-12", "fr-col-sm-9", "fr-grid-row", "fr-grid-row--middle")}>
-                                                    <h6
-                                                        style={{
-                                                            overflow: "hidden",
-                                                            textOverflow: "ellipsis",
-                                                            whiteSpace: "nowrap",
-                                                            display: "inline-block",
-                                                            maxWidth: "calc(100% - 5.5rem)",
-                                                        }}
-                                                        className={fr.cx("fr-mr-1w")}
-                                                    >
-                                                        {accessKey.name}
-                                                    </h6>
-                                                    {accessKey.type && (
-                                                        <Badge className={fr.cx("fr-mb-6v")} noIcon={true} severity={"info"}>
-                                                            {accessKey.type}
-                                                        </Badge>
-                                                    )}
-                                                </div>
-
-                                                <div className={`frx-flex-end-sm ${fr.cx("fr-col-12", "fr-col-sm-3", "fr-mb-6v")}`}>
-                                                    <Button
-                                                        title={tCommon("modify")}
-                                                        priority="primary"
-                                                        iconId="fr-icon-edit-line"
-                                                        size="small"
-                                                        onClick={() => {
-                                                            routes.user_key_edit({ keyId: accessKey._id }).push();
-                                                        }}
-                                                    />
-                                                    <Button
-                                                        title={tCommon("delete")}
-                                                        className={fr.cx("fr-ml-4v")}
-                                                        priority="secondary"
-                                                        iconId="fr-icon-delete-line"
-                                                        size="small"
-                                                        onClick={() => {
-                                                            setCurrentKey(accessKey._id);
-                                                            ConfirmDialogModal.open();
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                            {Object.entries(groupedServices).map(([type, services]) => {
+                                            {Object.entries(groupedServices).map(([type, services], typeIndex) => {
                                                 return (
                                                     <div key={type} className={fr.cx("fr-mb-5v")}>
-                                                        {accessKey.type_infos && (accessKey.type_infos as HashInfoDto).hash && (
-                                                            <div className={fr.cx("fr-col-12", "fr-col-lg-10")}>
-                                                                <UserKeyLink
-                                                                    permissionId={services[0].permission._id}
-                                                                    offeringId={services[0].offering._id}
-                                                                    hash={(accessKey.type_infos as HashInfoDto).hash}
-                                                                />
-                                                            </div>
-                                                        )}
-                                                        <div className={fr.cx("fr-mb-1v")}>
-                                                            {type === "WFS"
-                                                                ? t("wfs_services")
-                                                                : type === "WMS-RASTER"
-                                                                  ? t("wms_raster_services")
-                                                                  : type === "WMS-VECTOR"
-                                                                    ? t("wms_vector_services")
-                                                                    : type === "WMTS-TMS"
-                                                                      ? t("wmts_tms_services")
-                                                                      : null}
+                                                        {typeIndex >= 1 ? <hr /> : null}
+                                                        <div className={fr.cx("fr-col-12", "fr-col-lg-10")}>
+                                                            <UserKeyLink
+                                                                permissionId={services[0].permission._id}
+                                                                offeringId={services[0].offering._id}
+                                                                hash={accessKey.type_infos && (accessKey.type_infos as HashInfoDto).hash}
+                                                            />
                                                         </div>
+                                                        <div className={fr.cx("fr-mb-1v")}>{t("available_services")}</div>
                                                         <ul>
                                                             {services.map((service) => (
                                                                 <div key={service.offering._id}>
@@ -270,51 +260,10 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                         </>
                                     ) : (
                                         <>
-                                            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
-                                                <div className={fr.cx("fr-col-12", "fr-col-sm-9", "fr-grid-row", "fr-grid-row--middle")}>
-                                                    <h6
-                                                        style={{
-                                                            overflow: "hidden",
-                                                            textOverflow: "ellipsis",
-                                                            whiteSpace: "nowrap",
-                                                            display: "inline-block",
-                                                            maxWidth: "calc(100% - 5.5rem)",
-                                                        }}
-                                                        className={fr.cx("fr-mr-1w")}
-                                                    >
-                                                        {accessKey.name}
-                                                    </h6>
-                                                    {accessKey.type && (
-                                                        <Badge className={fr.cx("fr-mb-6v")} noIcon={true} severity={"info"}>
-                                                            {accessKey.type}
-                                                        </Badge>
-                                                    )}
-                                                </div>
-
-                                                <div className={`frx-flex-end-sm ${fr.cx("fr-col-12", "fr-col-sm-3", "fr-mb-6v")}`}>
-                                                    <Button
-                                                        title={tCommon("modify")}
-                                                        priority="primary"
-                                                        iconId="fr-icon-edit-line"
-                                                        size="small"
-                                                        onClick={() => {
-                                                            routes.user_key_edit({ keyId: accessKey._id }).push();
-                                                        }}
-                                                    />
-                                                    <Button
-                                                        title={tCommon("delete")}
-                                                        className={fr.cx("fr-ml-4v")}
-                                                        priority="secondary"
-                                                        iconId="fr-icon-delete-line"
-                                                        size="small"
-                                                        onClick={() => {
-                                                            setCurrentKey(accessKey._id);
-                                                            ConfirmDialogModal.open();
-                                                        }}
-                                                    />
-                                                </div>
-                                            </div>
-                                            <div className={fr.cx("fr-mb-1v")}>{t("no_services")}</div>
+                                            <Badge className={fr.cx("fr-mb-1v")} severity={"error"}>
+                                                {t("no_services_status")}
+                                            </Badge>
+                                            <div className={fr.cx("fr-mb-1v")}>{t("no_services_hint")}</div>
                                         </>
                                     )}
                                 </div>

--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -1,5 +1,4 @@
 import { fr } from "@codegouvfr/react-dsfr";
-import Accordion from "@codegouvfr/react-dsfr/Accordion";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
@@ -7,21 +6,23 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FC, useMemo, useState } from "react";
 
 import type { UserKeyDetailedWithAccessesResponseDto } from "../../../../../@types/app";
-import {
-    type HashInfoDto,
-    type PermissionWithOfferingsResponseDto,
-    UserKeyDetailsResponseDtoUserKeyInfoDtoTypeEnum,
-    type UserKeyResponseDto,
-} from "../../../../../@types/entrepot";
+import { type HashInfoDto, type PermissionWithOfferingsResponseDto, type UserKeyResponseDto } from "../../../../../@types/entrepot";
 import { ConfirmDialog, ConfirmDialogModal } from "../../../../../components/Utils/ConfirmDialog";
 import Wait from "../../../../../components/Utils/Wait";
 import { useTranslation } from "../../../../../i18n/i18n";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
 import { CartesApiException } from "../../../../../modules/jsonFetch";
-import { routes } from "../../../../../router/router";
+import { appRoot, routes } from "../../../../../router/router";
 import api from "../../../../api";
 import UserKeyLink from "./UserKeyLink";
-import TextCopyToClipboard from "@/components/Utils/TextCopyToClipboard";
+import SearchBar from "@codegouvfr/react-dsfr/SearchBar";
+import Tooltip from "@codegouvfr/react-dsfr/Tooltip";
+import TagsGroup from "@codegouvfr/react-dsfr/TagsGroup";
+import { TagProps } from "@codegouvfr/react-dsfr/Tag";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+
+import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg?no-inline";
+import padlock from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/padlock.svg?no-inline";
 
 type UserKeysListTabProps = {
     keys: UserKeyDetailedWithAccessesResponseDto[] | undefined;
@@ -34,26 +35,10 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
 
     const [currentKey, setCurrentKey] = useState<string | undefined>(undefined);
 
-    /* Y-a-t-il deja une cle OAUTH2 */
-    const hasOauth2 = useMemo(() => {
-        const f = keys?.find((key) => key.type === UserKeyDetailsResponseDtoUserKeyInfoDtoTypeEnum.OAUTH2);
-        return !!f;
-    }, [keys]);
-
     /* l'utilisateur a-t-il des permissions */
     const hasPermissions = useMemo(() => {
         return permissions !== undefined && permissions.length > 0;
     }, [permissions]);
-
-    /* Ces permissions sont-elles toutes only_oauth a true */
-    const permissionsAreAllOnlyOauth = useMemo(() => {
-        const oauths = permissions?.filter((permission) => permission.only_oauth) ?? [];
-        return oauths.length === permissions?.length;
-    }, [permissions]);
-
-    const canAdd = useMemo(() => {
-        return hasPermissions && !(hasOauth2 && permissionsAreAllOnlyOauth);
-    }, [hasPermissions, hasOauth2, permissionsAreAllOnlyOauth]);
 
     const queryClient = useQueryClient();
 
@@ -71,6 +56,9 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
         },
     });
 
+    const { copy } = useCopyToClipboard();
+    const [copiedText, setCopiedText] = useState<string | null>(null);
+
     return (
         <>
             {removeStatus === "error" && <Alert severity={"error"} closable title={tCommon("error")} description={removeError.message} />}
@@ -85,107 +73,257 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                 </Wait>
             )}
             {keys === undefined || keys.length === 0 ? (
-                <p>{t("no_keys")}</p>
+                <div className={fr.cx("fr-my-8w", "fr-mb-4w", "fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                    <div className={fr.cx("fr-col-12", "fr-col-sm-5", "fr-col-md-4", "fr-py-0")}>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className={fr.cx("fr-responsive-img", "fr-artwork")}
+                            aria-hidden="true"
+                            width="160"
+                            height="200"
+                            viewBox="0 0 160 200"
+                        >
+                            <use className={fr.cx("fr-artwork-motif")} href={`${ovoidSvgUrl}#artwork-motif`} />
+                            <use className={fr.cx("fr-artwork-background")} href={`${ovoidSvgUrl}#artwork-background`} />
+                            <g transform="translate(40, 60)">
+                                <use className={fr.cx("fr-artwork-decorative")} href={`${padlock}#artwork-decorative`} />
+                                <use className={fr.cx("fr-artwork-minor")} href={`${padlock}#artwork-minor`} />
+                                <use className={fr.cx("fr-artwork-major")} href={`${padlock}#artwork-major`} />
+                            </g>
+                        </svg>
+                    </div>
+                    <div className={fr.cx("fr-col-sm-7", "fr-col-md-8", "fr-pl-md-6w")}>
+                        <h6>{t("no_keys")}</h6>
+                        {t("explain_no_keys")}
+                        <Button
+                            linkProps={{
+                                href: appRoot + "/documentation/",
+                                target: "_blank",
+                                rel: "noreferrer",
+                                title: t("consult_documentation") + " - " + tCommon("new_window"),
+                            }}
+                            priority="secondary"
+                        >
+                            {t("consult_documentation")}
+                        </Button>
+                    </div>
+                </div>
             ) : (
-                keys.map((accessKey) => {
-                    const groupedServices = (accessKey.accesses ?? []).reduce(
-                        (acc, access) => {
-                            const type = access.offering.type;
-                            if (!acc[type]) {
-                                acc[type] = [];
-                            }
-                            acc[type].push(access);
-                            return acc;
-                        },
-                        {} as Record<string, typeof accessKey.accesses>
-                    );
+                <>
+                    <SearchBar
+                        className={fr.cx("fr-col-12", "fr-col-sm-7", "fr-col-lg-5", "fr-mt-10v", "fr-mb-5v")}
+                        label={tCommon("search")}
+                        allowEmptySearch={true}
+                    />
+                    <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                        <Tooltip title="Le nombre maximal de clés par utilisateur est de 10" />
+                        <h6 className={fr.cx("fr-mt-6v", "fr-mx-1w")}>{t("active_keys")}</h6>
+                        <Badge noIcon={true} severity={"info"}>
+                            {keys.length}/10
+                        </Badge>
+                    </div>
 
-                    return (
-                        <div key={accessKey._id} className={fr.cx("fr-my-1v")}>
-                            <Accordion
-                                label={
-                                    <div>
-                                        {accessKey.name}
-                                        {accessKey.type && (
-                                            <Badge className={fr.cx("fr-ml-2v")} noIcon={true} severity={"info"}>
-                                                {accessKey.type}
-                                            </Badge>
-                                        )}
-                                    </div>
+                    {keys.map((accessKey) => {
+                        const groupedServices = (accessKey.accesses ?? []).reduce(
+                            (acc, access) => {
+                                const type = access.offering.type;
+                                if (!acc[type]) {
+                                    acc[type] = [];
                                 }
-                            >
-                                <div>
+                                acc[type].push(access);
+                                return acc;
+                            },
+                            {} as Record<string, typeof accessKey.accesses>
+                        );
+
+                        console.log("ACCESSKEY", accessKey);
+
+                        const tags: TagProps[] = [];
+
+                        if (accessKey.blacklist?.length || accessKey.whitelist?.length) {
+                            tags.push({ children: "Filtrage par IP", iconId: "fr-icon-check-line" });
+                        }
+
+                        if (accessKey.user_agent?.trim()) {
+                            tags.push({ children: "User agent", iconId: "fr-icon-check-line" });
+                        }
+
+                        if (accessKey.referer?.trim()) {
+                            tags.push({ children: "Referer", iconId: "fr-icon-check-line" });
+                        }
+
+                        return (
+                            <div key={accessKey._id} className={fr.cx("fr-my-1v")}>
+                                <div
+                                    className={fr.cx("fr-mb-5v", "fr-px-6v", "fr-py-3w")}
+                                    style={{ border: "1px solid", borderColor: fr.colors.decisions.border.default.grey.default }}
+                                >
                                     {accessKey.accesses !== undefined && accessKey.accesses.length !== 0 ? (
                                         <>
-                                            {accessKey.type && accessKey.type === UserKeyDetailsResponseDtoUserKeyInfoDtoTypeEnum.HASH && (
-                                                <TextCopyToClipboard
-                                                    label={t("hash_value")}
-                                                    text={(accessKey.type_infos as HashInfoDto).hash ?? t("unavailable")}
-                                                    disabled={!(accessKey.type_infos as HashInfoDto).hash}
-                                                />
-                                            )}
-                                            <div className={fr.cx("fr-mb-1v")}>{t("services")}</div>
+                                            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                                                <div className={fr.cx("fr-col-12", "fr-col-sm-9", "fr-grid-row", "fr-grid-row--middle")}>
+                                                    <h6
+                                                        style={{
+                                                            overflow: "hidden",
+                                                            textOverflow: "ellipsis",
+                                                            whiteSpace: "nowrap",
+                                                            display: "inline-block",
+                                                            maxWidth: "calc(100% - 5.5rem)",
+                                                        }}
+                                                        className={fr.cx("fr-mr-1w")}
+                                                    >
+                                                        {accessKey.name}
+                                                    </h6>
+                                                    {accessKey.type && (
+                                                        <Badge className={fr.cx("fr-mb-6v")} noIcon={true} severity={"info"}>
+                                                            {accessKey.type}
+                                                        </Badge>
+                                                    )}
+                                                </div>
+
+                                                <div className={`frx-flex-end-sm ${fr.cx("fr-col-12", "fr-col-sm-3", "fr-mb-6v")}`}>
+                                                    <Button
+                                                        title={tCommon("modify")}
+                                                        priority="primary"
+                                                        iconId="fr-icon-edit-line"
+                                                        size="small"
+                                                        onClick={() => {
+                                                            routes.user_key_edit({ keyId: accessKey._id }).push();
+                                                        }}
+                                                    />
+                                                    <Button
+                                                        title={tCommon("delete")}
+                                                        className={fr.cx("fr-ml-4v")}
+                                                        priority="secondary"
+                                                        iconId="fr-icon-delete-line"
+                                                        size="small"
+                                                        onClick={() => {
+                                                            setCurrentKey(accessKey._id);
+                                                            ConfirmDialogModal.open();
+                                                        }}
+                                                    />
+                                                </div>
+                                            </div>
                                             {Object.entries(groupedServices).map(([type, services]) => {
                                                 return (
                                                     <div key={type} className={fr.cx("fr-mb-5v")}>
-                                                        <Badge className={fr.cx("fr-ml-2v")} noIcon={true} severity={"info"}>
-                                                            {type}
-                                                        </Badge>
+                                                        {accessKey.type_infos && (accessKey.type_infos as HashInfoDto).hash && (
+                                                            <div className={fr.cx("fr-col-12", "fr-col-lg-10")}>
+                                                                <UserKeyLink
+                                                                    permissionId={services[0].permission._id}
+                                                                    offeringId={services[0].offering._id}
+                                                                    hash={(accessKey.type_infos as HashInfoDto).hash}
+                                                                />
+                                                            </div>
+                                                        )}
+                                                        <div className={fr.cx("fr-mb-1v")}>
+                                                            {type === "WFS"
+                                                                ? t("wfs_services")
+                                                                : type === "WMS-RASTER"
+                                                                  ? t("wms_raster_services")
+                                                                  : type === "WMS-VECTOR"
+                                                                    ? t("wms_vector_services")
+                                                                    : type === "WMTS-TMS"
+                                                                      ? t("wmts_tms_services")
+                                                                      : null}
+                                                        </div>
                                                         <ul>
                                                             {services.map((service) => (
-                                                                <li key={service.offering._id}>{service.offering.layer_name}</li>
+                                                                <div key={service.offering._id}>
+                                                                    <li
+                                                                        className={fr.cx("fr-grid-row", "fr-grid-row--middle")}
+                                                                        style={{ marginBottom: "0.2rem" }}
+                                                                    >
+                                                                        <div
+                                                                            style={{
+                                                                                overflow: "hidden",
+                                                                                textOverflow: "ellipsis",
+                                                                                whiteSpace: "nowrap",
+                                                                                display: "inline-block",
+                                                                                maxWidth: "calc(100% - 2.5rem)",
+                                                                            }}
+                                                                        >
+                                                                            &bull; {service.offering.layer_name}
+                                                                        </div>
+                                                                        <Button
+                                                                            title={tCommon("copy_to_clipboard")}
+                                                                            className={fr.cx("fr-ml-1w")}
+                                                                            priority="tertiary"
+                                                                            iconId={
+                                                                                copiedText === service.offering._id ? "fr-icon-check-line" : "ri-file-copy-line"
+                                                                            }
+                                                                            size="small"
+                                                                            onClick={() => {
+                                                                                copy(service.offering.layer_name);
+                                                                                setCopiedText(service.offering._id);
+                                                                                setTimeout(() => setCopiedText(null), 5000);
+                                                                            }}
+                                                                        />
+                                                                    </li>
+                                                                </div>
                                                             ))}
                                                         </ul>
-                                                        {accessKey.type_infos && (accessKey.type_infos as HashInfoDto).hash && (
-                                                            <UserKeyLink
-                                                                permissionId={services[0].permission._id}
-                                                                offeringId={services[0].offering._id}
-                                                                hash={(accessKey.type_infos as HashInfoDto).hash}
-                                                            />
-                                                        )}
                                                     </div>
                                                 );
                                             })}
+                                            {tags.length > 0 && <TagsGroup tags={tags as [TagProps, ...TagProps[]]} />}
                                         </>
                                     ) : (
-                                        <div className={fr.cx("fr-mb-1v")}>{t("no_services")}</div>
+                                        <>
+                                            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                                                <div className={fr.cx("fr-col-12", "fr-col-sm-9", "fr-grid-row", "fr-grid-row--middle")}>
+                                                    <h6
+                                                        style={{
+                                                            overflow: "hidden",
+                                                            textOverflow: "ellipsis",
+                                                            whiteSpace: "nowrap",
+                                                            display: "inline-block",
+                                                            maxWidth: "calc(100% - 5.5rem)",
+                                                        }}
+                                                        className={fr.cx("fr-mr-1w")}
+                                                    >
+                                                        {accessKey.name}
+                                                    </h6>
+                                                    {accessKey.type && (
+                                                        <Badge className={fr.cx("fr-mb-6v")} noIcon={true} severity={"info"}>
+                                                            {accessKey.type}
+                                                        </Badge>
+                                                    )}
+                                                </div>
+
+                                                <div className={`frx-flex-end-sm ${fr.cx("fr-col-12", "fr-col-sm-3", "fr-mb-6v")}`}>
+                                                    <Button
+                                                        title={tCommon("modify")}
+                                                        priority="primary"
+                                                        iconId="fr-icon-edit-line"
+                                                        size="small"
+                                                        onClick={() => {
+                                                            routes.user_key_edit({ keyId: accessKey._id }).push();
+                                                        }}
+                                                    />
+                                                    <Button
+                                                        title={tCommon("delete")}
+                                                        className={fr.cx("fr-ml-4v")}
+                                                        priority="secondary"
+                                                        iconId="fr-icon-delete-line"
+                                                        size="small"
+                                                        onClick={() => {
+                                                            setCurrentKey(accessKey._id);
+                                                            ConfirmDialogModal.open();
+                                                        }}
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div className={fr.cx("fr-mb-1v")}>{t("no_services")}</div>
+                                        </>
                                     )}
-                                    <div className={fr.cx("fr-grid-row", "fr-my-2v")}>
-                                        <Button
-                                            title={tCommon("modify")}
-                                            priority="secondary"
-                                            iconId="fr-icon-edit-line"
-                                            size="small"
-                                            onClick={() => {
-                                                routes.user_key_edit({ keyId: accessKey._id }).push();
-                                            }}
-                                        >
-                                            {tCommon("modify")}
-                                        </Button>
-                                        <Button
-                                            title={tCommon("delete")}
-                                            className={fr.cx("fr-ml-2v")}
-                                            priority="secondary"
-                                            iconId="fr-icon-delete-line"
-                                            size="small"
-                                            onClick={() => {
-                                                setCurrentKey(accessKey._id);
-                                                ConfirmDialogModal.open();
-                                            }}
-                                        >
-                                            {tCommon("delete")}
-                                        </Button>
-                                    </div>
                                 </div>
-                            </Accordion>
-                        </div>
-                    );
-                })
+                            </div>
+                        );
+                    })}
+                </>
             )}
             {hasPermissions === false && <p>{t("no_permission_warning")}</p>}
-            <Button className={fr.cx("fr-my-2v")} {...(canAdd ? { linkProps: routes.user_key_add().link } : { disabled: true })}>
-                {t("add")}
-            </Button>
             <ConfirmDialog
                 title={t("confirm_remove")}
                 onConfirm={() => {

--- a/assets/entrepot/pages/users/permissions/Permissions.locale.tsx
+++ b/assets/entrepot/pages/users/permissions/Permissions.locale.tsx
@@ -41,7 +41,7 @@ export const PermissionsFrTranslations: Translations<"fr">["Permissions"] = {
     explain_permissions:
         "Consulter les permissions qui vous ont été octroyées par les producteurs de données, leurs services associés et leur date d'expiration.",
     sorting: "Tri",
-    type_sorting: "Filtrer par flux",
+    type_sorting: "Filtrer par type",
     alphabetical_order: "Ordre alphabétique de A à Z",
     reverse_alphabetical_order: "Ordre alphabétique de Z à A",
     latest_date: "Date d'expiration la plus récente",

--- a/assets/entrepot/pages/users/permissions/Permissions.locale.tsx
+++ b/assets/entrepot/pages/users/permissions/Permissions.locale.tsx
@@ -5,7 +5,19 @@ import { Translations } from "../../../../i18n/types";
 const { i18n } = declareComponentKeys<
     | "title"
     | "services"
-    | "no_permission"
+    | "no_permissions"
+    | { K: "explain_no_permissions"; R: JSX.Element }
+    | "consult_documentation"
+    | "discover_workspaces"
+    | "explain_permissions"
+    | "sorting"
+    | "type_sorting"
+    | "alphabetical_order"
+    | "reverse_alphabetical_order"
+    | "latest_date"
+    | "oldest_date"
+    | "active_permissions"
+    | "permissions_expired"
     | { K: "expired"; P: { date: string | null }; R: string }
     | { K: "expires_on"; P: { date: string }; R: string }
     | { K: "permission_expires_on"; P: { date: string }; R: string }
@@ -16,7 +28,26 @@ export type I18n = typeof i18n;
 export const PermissionsFrTranslations: Translations<"fr">["Permissions"] = {
     title: "Permissions",
     services: "Services",
-    no_permission: "Vous n'avez aucune permission",
+    no_permissions: "Vous n’avez pas de permissions.",
+    explain_no_permissions: (
+        <>
+            {"Les permissions sont des autorisation de producteurs de données publiques ou privées qui vous sont accordées pour exploiter leurs données."}
+            <br />
+            <p>{"Pour obtenir ces permissions, rejoingnez des espaces de travail."}</p>
+        </>
+    ),
+    consult_documentation: "Consulter la documentation",
+    discover_workspaces: "Découvrir les espaces de travail",
+    explain_permissions:
+        "Consulter les permissions qui vous ont été octroyées par les producteurs de données, leurs services associés et leur date d'expiration.",
+    sorting: "Tri",
+    type_sorting: "Filtrer par flux",
+    alphabetical_order: "Ordre alphabétique de A à Z",
+    reverse_alphabetical_order: "Ordre alphabétique de Z à A",
+    latest_date: "Date d'expiration la plus récente",
+    oldest_date: "Date d'expiration la plus ancienne",
+    active_permissions: "Permissions actives",
+    permissions_expired: "Permissions expirées",
     expired: ({ date }) => (date ? `A expiré le ${date}` : "A expirée"),
     expires_on: ({ date }) => `Expire le ${date}`,
     permission_expires_on: ({ date }) => `Cette permission expire le ${date}`,
@@ -26,7 +57,25 @@ export const PermissionsFrTranslations: Translations<"fr">["Permissions"] = {
 export const PermissionsEnTranslations: Translations<"en">["Permissions"] = {
     title: "Permissions",
     services: "Services",
-    no_permission: "You have no permission",
+    no_permissions: "You have no permissions.",
+    explain_no_permissions: (
+        <>
+            {"Permissions are authorisations granted by public or private data producers to use their data."}
+            <br />
+            <p>{"To obtain these permissions, join workspaces."}</p>
+        </>
+    ),
+    consult_documentation: "Consult the documentation",
+    discover_workspaces: "Discover the workspaces",
+    explain_permissions: "View the permissions granted to you by data producers, their associated services, and their expiry dates.",
+    sorting: "Sorting",
+    type_sorting: undefined,
+    alphabetical_order: "Alphabetical order from A to Z",
+    reverse_alphabetical_order: "Alphabetical order from Z to A",
+    latest_date: "Latest expiry date",
+    oldest_date: "Oldest expiry date",
+    active_permissions: "Active permissions",
+    permissions_expired: "Permissions expired",
     expired: ({ date }) => (date ? `Expired on ${date}` : "Expired"),
     expires_on: ({ date }) => `Expires on ${date})`,
     permission_expires_on: ({ date }) => `Permission expires on ${date}`,

--- a/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
+++ b/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
@@ -37,13 +37,9 @@ const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
 
     if (!permissions) return null;
 
-    const normalizeType = (type: string) => {
-        if (type === "WMTS-RASTER") return "WMTS-RASTER";
-        if (type === "WMTS-VECTOR") return "WMTS-VECTOR";
-        if (type === "WMTS-TMS") return "WMTS_TMS";
-        if (type === "WFS") return "WFS";
-        return type;
-    };
+    const availableTypes = Array.from(new Set((permissions ?? []).flatMap((permission) => (permission.offerings ?? []).map((offering) => offering.type)))).sort(
+        (a, b) => a.localeCompare(b, "fr", { sensitivity: "base" })
+    );
 
     const filteredAndSortedPermissions = [...(permissions ?? [])]
         .map((permission) => {
@@ -54,7 +50,7 @@ const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
         .filter((permission) => {
             if (!fluxValue) return true;
             const offerings = permission.offerings ?? [];
-            return offerings.some((offering) => normalizeType(offering.type) === fluxValue);
+            return offerings.some((offering) => offering.type === fluxValue);
         })
         .sort((a, b) => {
             switch (sortValue) {
@@ -181,10 +177,11 @@ const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
                         <option value="" disabled hidden>
                             {tCommon("select_option")}
                         </option>
-                        <option value="WMS-RASTER">WMS-RASTER</option>
-                        <option value="WMS-VECTOR">WMS-VECTOR</option>
-                        <option value="WMTS_TMS">WMTS / TMS</option>
-                        <option value="WFS">WFS</option>
+                        {availableTypes.map((type) => (
+                            <option key={type} value={type}>
+                                {type}
+                            </option>
+                        ))}
                     </Select>
                 </div>
             )}

--- a/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
+++ b/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
@@ -1,66 +1,262 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import { compareAsc } from "date-fns";
-import { FC } from "react";
+import { FC, useState } from "react";
 
 import { PermissionWithOfferingsDetailsResponseDto } from "../../../../@types/entrepot";
 import { useTranslation } from "../../../../i18n/i18n";
 import { formatDateWithoutTimeFromISO } from "../../../../utils";
+import { appRoot } from "../../../../router/router";
 
 import "../../../../sass/pages/my_keys.scss";
+import ovoidSvgUrl from "@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg?no-inline";
+import padlock from "@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/padlock.svg?no-inline";
+import Select from "@codegouvfr/react-dsfr/Select";
+import Button from "@codegouvfr/react-dsfr/Button";
 
 type PermissionsListTabProps = {
     permissions: PermissionWithOfferingsDetailsResponseDto[] | undefined;
 };
 
 const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
+    const { t: tCommon } = useTranslation("Common");
     const { t } = useTranslation("Permissions");
 
+    const [filter, setFilter] = useState<"active" | "expired">("active");
+
+    const [showFilters, setShowFilters] = useState(false);
+    const [sortValue, setSortValue] = useState("");
+    const [fluxValue, setFluxValue] = useState("");
+    const toggleFilters = () => {
+        if (showFilters) {
+            setSortValue("");
+            setFluxValue("");
+        }
+        setShowFilters((prev) => !prev);
+    };
+
+    if (!permissions) return null;
+
+    const normalizeType = (type: string) => {
+        if (type.startsWith("WMS")) return "WMS";
+        if (type === "WMTS-TMS") return "WMTS_TMS";
+        if (type === "WFS") return "WFS";
+        return type;
+    };
+
+    const filteredAndSortedPermissions = [...(permissions ?? [])]
+        .map((permission) => {
+            const expired = permission.end_date && compareAsc(new Date(permission.end_date), new Date()) < 0;
+            return { ...permission, expired };
+        })
+        .filter((p) => (filter === "expired" ? p.expired : !p.expired))
+        .filter((permission) => {
+            if (!fluxValue) return true;
+            const offerings = permission.offerings ?? [];
+            return offerings.some((offering) => normalizeType(offering.type) === fluxValue);
+        })
+        .sort((a, b) => {
+            switch (sortValue) {
+                case "alphabetical_order":
+                    return a.licence.localeCompare(b.licence, "fr", { sensitivity: "base" });
+                case "reverse_alphabetical_order":
+                    return b.licence.localeCompare(a.licence, "fr", { sensitivity: "base" });
+                case "latest_date": {
+                    const dateA = a.end_date ? new Date(a.end_date).getTime() : 0;
+                    const dateB = b.end_date ? new Date(b.end_date).getTime() : 0;
+                    return dateB - dateA;
+                }
+                case "oldest_date": {
+                    const dateA = a.end_date ? new Date(a.end_date).getTime() : Number.MAX_SAFE_INTEGER;
+                    const dateB = b.end_date ? new Date(b.end_date).getTime() : Number.MAX_SAFE_INTEGER;
+                    return dateA - dateB;
+                }
+                default:
+                    return 0;
+            }
+        });
+
+    const expiredCount = filteredAndSortedPermissions
+        ? filteredAndSortedPermissions.filter((p) => p.end_date && compareAsc(new Date(p.end_date), new Date()) < 0).length
+        : 0;
+
+    const activeCount = filteredAndSortedPermissions ? filteredAndSortedPermissions.length - expiredCount : 0;
+
     return permissions === undefined || permissions.length === 0 ? (
-        <p>{t("no_permission")}</p>
+        <div className={fr.cx("fr-my-8w", "fr-mb-4w", "fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+            <div className={fr.cx("fr-col-12", "fr-col-sm-5", "fr-col-md-4", "fr-py-0")}>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className={fr.cx("fr-responsive-img", "fr-artwork")}
+                    aria-hidden="true"
+                    width="160"
+                    height="200"
+                    viewBox="0 0 160 200"
+                >
+                    <use className={fr.cx("fr-artwork-motif")} href={`${ovoidSvgUrl}#artwork-motif`} />
+                    <use className={fr.cx("fr-artwork-background")} href={`${ovoidSvgUrl}#artwork-background`} />
+                    <g transform="translate(40, 60)">
+                        <use className={fr.cx("fr-artwork-decorative")} href={`${padlock}#artwork-decorative`} />
+                        <use className={fr.cx("fr-artwork-minor")} href={`${padlock}#artwork-minor`} />
+                        <use className={fr.cx("fr-artwork-major")} href={`${padlock}#artwork-major`} />
+                    </g>
+                </svg>
+            </div>
+            <div className={fr.cx("fr-col-sm-7", "fr-col-md-8", "fr-pl-md-6w")}>
+                <h6>{t("no_permissions")}</h6>
+                {t("explain_no_permissions")}
+                <div>
+                    <a
+                        className={fr.cx("fr-link")}
+                        href={appRoot + "/documentation/"}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={t("consult_documentation") + " - " + tCommon("new_window")}
+                    >
+                        {t("consult_documentation")}
+                    </a>
+                </div>
+                <div className={fr.cx("fr-mt-2v")}>
+                    <a
+                        className={fr.cx("fr-link", "fr-icon-arrow-right-line", "fr-link--icon-right")}
+                        href={appRoot + "/tableau-de-bord/"}
+                        rel="noreferrer"
+                        title={t("discover_workspaces") + " - " + tCommon("new_window")}
+                    >
+                        {t("discover_workspaces")}
+                    </a>
+                </div>
+            </div>
+        </div>
     ) : (
         <div>
-            {permissions.map((permission, index) => {
-                const className = index % 2 === 0 ? "frx-permission frx-permission-even" : "frx-permission";
+            <p>{t("explain_permissions")}</p>
+            <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mt-10v", "fr-mb-5v")}>
+                <Select
+                    label={null}
+                    className={fr.cx("fr-col-12", "fr-col-lg-6")}
+                    nativeSelectProps={{
+                        onChange: (event) => setFilter(event.target.value as "active" | "expired"),
+                        value: filter,
+                    }}
+                >
+                    <option value="active">{t("active_permissions")}</option>
+                    <option value="expired">{t("permissions_expired")}</option>
+                </Select>
+                <Button
+                    className={fr.cx("fr-mt-3v", "fr-ml-1w")}
+                    priority="tertiary"
+                    title={showFilters ? tCommon("remove_filters") : tCommon("filter")}
+                    iconId={showFilters ? "fr-icon-filter-fill" : "fr-icon-filter-line"}
+                    onClick={toggleFilters}
+                />
+            </div>
+            {showFilters && (
+                <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-mb-5v")}>
+                    <Select
+                        className={fr.cx("fr-col-6", "fr-col-sm-5")}
+                        label={t("sorting")}
+                        nativeSelectProps={{
+                            value: sortValue,
+                            onChange: (e) => setSortValue(e.target.value),
+                        }}
+                    >
+                        <option value="" disabled hidden>
+                            {tCommon("select_option")}
+                        </option>
+                        <option value="alphabetical_order">{t("alphabetical_order")}</option>
+                        <option value="reverse_alphabetical_order">{t("reverse_alphabetical_order")}</option>
+                        <option value="latest_date">{t("latest_date")}</option>
+                        <option value="oldest_date">{t("oldest_date")}</option>
+                    </Select>
+                    <Select
+                        className={fr.cx("fr-col-6", "fr-col-sm-5")}
+                        label={t("type_sorting")}
+                        nativeSelectProps={{
+                            value: fluxValue,
+                            onChange: (e) => setFluxValue(e.target.value),
+                        }}
+                    >
+                        <option value="" disabled hidden>
+                            {tCommon("select_option")}
+                        </option>
+                        <option value="WMS">WMS</option>
+                        <option value="WMTS_TMS">WMTS / TMS</option>
+                        <option value="WFS">WFS</option>
+                    </Select>
+                </div>
+            )}
 
-                let expired = false;
-                if (permission.end_date && compareAsc(new Date(permission.end_date), new Date()) < 0) {
-                    expired = true;
-                }
-                const expiresOn = permission.end_date ? formatDateWithoutTimeFromISO(permission.end_date) : null;
+            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters", "fr-mb-2v", "fr-ml-1w")}>
+                {filter === "active" ? (
+                    <>
+                        <span className={fr.cx("fr-icon-check-line")} />
+                        <h3 className={fr.cx("fr-mt-6v", "fr-mx-1w")}>{t("active_permissions")}</h3>
+                        <Badge noIcon severity="info">
+                            {activeCount}
+                        </Badge>
+                    </>
+                ) : (
+                    <>
+                        <span className={fr.cx("fr-icon-close-line")} />
+                        <h3 className={fr.cx("fr-mt-6v", "fr-mx-1w")}>{t("permissions_expired")}</h3>
+                        <Badge noIcon severity="info">
+                            {expiredCount}
+                        </Badge>
+                    </>
+                )}
+            </div>
 
-                return (
-                    <div key={permission._id} className={className}>
-                        <div className={fr.cx("fr-mb-1v")}>
-                            {expired ? (
-                                <Badge severity="warning">{t("expired", { date: expiresOn })}</Badge>
-                            ) : (
-                                expiresOn && <div>{t("expires_on", { date: expiresOn })}</div>
-                            )}
+            {filteredAndSortedPermissions
+                .map((permission) => {
+                    const expired = permission.end_date && compareAsc(new Date(permission.end_date), new Date()) < 0;
+
+                    return { ...permission, expired };
+                })
+                .filter((p) => (filter === "expired" ? p.expired : !p.expired))
+                .map((permission) => {
+                    const expiresOn = permission.end_date ? formatDateWithoutTimeFromISO(permission.end_date) : null;
+
+                    return (
+                        <div
+                            key={permission._id}
+                            className={fr.cx("fr-mb-5v", "fr-px-6v", "fr-py-3w")}
+                            style={{
+                                border: "1px solid",
+                                borderColor: fr.colors.decisions.border.default.grey.default,
+                            }}
+                        >
+                            <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+                                <h4 className={`frx-col-md-auto ${fr.cx("fr-col-12")}`}>{permission.licence}</h4>
+                                <div className={`frx-flex-end-md frx-col-md-auto ${fr.cx("fr-col-12", "fr-mb-6v")}`}>
+                                    {permission.expired ? (
+                                        <Badge severity="warning">{t("expired", { date: expiresOn })}</Badge>
+                                    ) : (
+                                        expiresOn && <div>{t("expires_on", { date: expiresOn })}</div>
+                                    )}
+                                </div>
+                            </div>
+                            <ul>
+                                {permission.offerings
+                                    .sort((a, b) =>
+                                        a.layer_name.localeCompare(b.layer_name, "fr", {
+                                            sensitivity: "base",
+                                        })
+                                    )
+                                    .map((offering) => (
+                                        <li key={offering._id} className={fr.cx("fr-mb-1v")}>
+                                            <span>
+                                                {offering.layer_name}
+                                                <Badge className={fr.cx("fr-ml-1w")} noIcon severity="info">
+                                                    {offering.type}
+                                                </Badge>
+                                            </span>
+                                        </li>
+                                    ))}
+                            </ul>
                         </div>
-                        <ul className={fr.cx("fr-raw-list")}>
-                            {permission.offerings
-                                .sort((a, b) => {
-                                    return a.layer_name.toLocaleLowerCase() < b.layer_name.toLocaleLowerCase()
-                                        ? -1
-                                        : a.layer_name.toLocaleLowerCase() > b.layer_name.toLocaleLowerCase()
-                                          ? 1
-                                          : 0;
-                                })
-                                .map((offering) => (
-                                    <li key={offering._id}>
-                                        <span>
-                                            {offering.layer_name}
-                                            <Badge className={fr.cx("fr-ml-1v")} noIcon severity="info">
-                                                {offering.type}
-                                            </Badge>
-                                        </span>
-                                    </li>
-                                ))}
-                        </ul>
-                    </div>
-                );
-            })}
+                    );
+                })}
         </div>
     );
 };

--- a/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
+++ b/assets/entrepot/pages/users/permissions/PermissionsListTab.tsx
@@ -38,7 +38,8 @@ const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
     if (!permissions) return null;
 
     const normalizeType = (type: string) => {
-        if (type.startsWith("WMS")) return "WMS";
+        if (type === "WMTS-RASTER") return "WMTS-RASTER";
+        if (type === "WMTS-VECTOR") return "WMTS-VECTOR";
         if (type === "WMTS-TMS") return "WMTS_TMS";
         if (type === "WFS") return "WFS";
         return type;
@@ -180,7 +181,8 @@ const PermissionsListTab: FC<PermissionsListTabProps> = ({ permissions }) => {
                         <option value="" disabled hidden>
                             {tCommon("select_option")}
                         </option>
-                        <option value="WMS">WMS</option>
+                        <option value="WMS-RASTER">WMS-RASTER</option>
+                        <option value="WMS-VECTOR">WMS-VECTOR</option>
                         <option value="WMTS_TMS">WMTS / TMS</option>
                         <option value="WFS">WFS</option>
                     </Select>

--- a/assets/i18n/Common.locale.tsx
+++ b/assets/i18n/Common.locale.tsx
@@ -47,6 +47,9 @@ const { i18n } = declareComponentKeys<
     | "search"
     | "clear"
     | "refresh"
+    | "filter"
+    | "remove_filters"
+    | "select_option"
     | { K: "last_refresh_date"; P: { dataUpdatedAt: number }; R: string }
     | { K: "nb_results"; P: { nb: number }; R: string }
 >()("Common");
@@ -97,6 +100,9 @@ export const commonFrTranslations: Translations<"fr">["Common"] = {
     search: "Rechercher",
     clear: "Effacer",
     refresh: "Rafraîchir",
+    filter: "Filtrer",
+    remove_filters: "Retirer les filtres",
+    select_option: "Sélectionnez une option",
     last_refresh_date: ({ dataUpdatedAt }) => `Données mises à jour le ${formatDateFromISO(new Date(dataUpdatedAt).toISOString())}`,
     nb_results: ({ nb }) => (nb > 1 ? `${nb} résultats` : `${nb} résultat`),
 };
@@ -146,6 +152,9 @@ export const commonEnTranslations: Translations<"en">["Common"] = {
     search: "Search",
     clear: "Clear",
     refresh: undefined,
+    filter: "Filter",
+    remove_filters: "Remove the filters",
+    select_option: "Select an option",
     last_refresh_date: undefined,
     nb_results: undefined,
 };

--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -43,3 +43,10 @@
         height: 100%;
     }
 }
+
+@media (min-width: 576px) {
+    .frx-btns-group--right-sm {
+        display: flex;
+        justify-content: flex-end;
+    }
+}

--- a/assets/sass/helpers.scss
+++ b/assets/sass/helpers.scss
@@ -9,7 +9,30 @@
         margin-top: 0 !important;
     }
     .frx-flex-end-sm {
+        margin-left: auto;
         display: flex !important;
         justify-content: flex-end !important;
+    }
+
+    .frx-col-sm-auto {
+        flex: 0 1 auto !important;
+        width: auto !important;
+        max-width: none !important;
+        min-width: 0 !important;
+    }
+}
+
+@media (min-width: 768px) {
+    .frx-flex-end-md {
+        margin-left: auto;
+        display: flex !important;
+        justify-content: flex-end !important;
+    }
+
+    .frx-col-md-auto {
+        flex: 0 1 auto !important;
+        width: auto !important;
+        max-width: none !important;
+        min-width: 0 !important;
     }
 }

--- a/assets/sass/helpers.scss
+++ b/assets/sass/helpers.scss
@@ -3,3 +3,13 @@
         text-align: right !important;
     }
 }
+
+@media (min-width: 576px) {
+    .frx-mt-sm-0 {
+        margin-top: 0 !important;
+    }
+    .frx-flex-end-sm {
+        display: flex !important;
+        justify-content: flex-end !important;
+    }
+}

--- a/assets/sass/pages/my_keys.scss
+++ b/assets/sass/pages/my_keys.scss
@@ -1,10 +1,3 @@
-.frx-permission {
-    padding: 0.5rem;
-}
-.frx-permission-even {
-    background-color: var(--background-alt-grey);
-}
-
 .fr-input-group--error label span.layer-name {
     color: var(--text-label-grey);
 }


### PR DESCRIPTION
Refonte des interfaces mes clés et mes permissions conformément aux maquettes.

- affichage systématique des urls des services
- tri sur le nom de la clé
- filtrage des clés par type de service accessible
- filtrage des permissions actives / expirées
- clarification des messages d'erreur lorsque les clés n'ont plus de services associés
- amélioration de la page lorsqu'aucune clé n'est présente

Pour plus tard :
- recherche (peu utile pour la majorité des utilisateurs qui n'ont qu'un quota de 10 clés)
