### PR TITLE
fix: avoid NaN et largeur minimale

### DIFF
--- a/assets/components/Utils/Progress.tsx
+++ b/assets/components/Utils/Progress.tsx
@@ -10,7 +10,8 @@ type ProgressProps = {
 };
 const Progress: FC<ProgressProps> = ({ label, value, max = 100 }) => {
     const percent = useMemo(() => {
-        const percentage = Math.floor((value / max) * 100);
+        const raw = (value / max) * 100;
+        const percentage = Number.isFinite(raw) ? Math.floor(raw) : 0;
 
         return `${percentage}%`;
     }, [max, value]);

--- a/assets/sass/components/progress.scss
+++ b/assets/sass/components/progress.scss
@@ -35,6 +35,7 @@
     white-space: nowrap;
     background-color: #007bff;
     transition: width 0.6s ease;
+    min-width: max-content;
 }
 
 .progress-bar-animated {


### PR DESCRIPTION
* évite l'affichage de NaN, affiche zéro à la place

<img width="470" height="293" alt="image" src="https://github.com/user-attachments/assets/80bb0b5c-7c7b-4952-ad4e-493ad522006b" />

* évite que le pourcentage ne soit pas lisible lorsque la barre est trop petite. Le texte blanc est toujours sur le fond bleu de la barre.