### PR TITLE
fix: texte accusé réception demande d'accès (#943)

### DIFF
--- a/translations/cartesgouvfr.fr.yml
+++ b/translations/cartesgouvfr.fr.yml
@@ -68,7 +68,7 @@ accesses_request:
         community: "%community% (id=%id%)"
         rendez_vous: "Rendez-vous dans l’espace de travail à partir duquel vous avez publié ces services pour ajouter les permissions nécessaires."
     email_acknowledgement:
-        heading: "Votre demande a été envoyée à l’IGN et une réponse vous sera apportée dans les meilleurs délais."
+        heading: "Votre demande a été envoyée au responsable de la donnée et une réponse vous sera apportée dans les meilleurs délais."
         date: "Date d’envoi"
         message: "Rappel de votre demande"
 


### PR DESCRIPTION
Petite modification à valider @AHeurion .

"à l'IGN" devient "au responsable de la donnée" si ça te va.