### PR TITLE
perf: préchargement des services dans la fiche de données

### DIFF
--- a/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetView.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetView.tsx
@@ -6,7 +6,7 @@ import { ButtonsGroup } from "@codegouvfr/react-dsfr/ButtonsGroup";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { Tabs } from "@codegouvfr/react-dsfr/Tabs";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FC, lazy, Suspense, useMemo } from "react";
+import { FC, lazy, Suspense, useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { symToStr } from "tsafe/symToStr";
 
@@ -83,6 +83,15 @@ const DatasheetView: FC<DatasheetViewProps> = ({ datastoreId, datasheetName }) =
         retry: false,
         enabled: !datasheetDeleteMutation.isPending,
     });
+
+    useEffect(() => {
+        // On précharge les données des services parce qu'on les a déjà à ce niveau-là
+        if (datasheetQuery.data?.service_list) {
+            datasheetQuery.data.service_list.forEach((service) => {
+                queryClient.setQueryData(RQKeys.datastore_offering(datastoreId, service._id), service);
+            });
+        }
+    }, [datasheetQuery.data?.service_list, datastoreId, queryClient]);
 
     const metadataQuery = useQuery<Metadata, CartesApiException>({
         queryKey: RQKeys.datastore_datasheet_metadata(datastoreId, datasheetName),

--- a/assets/entrepot/pages/service/tms/PyramidVectorTmsServiceForm/PyramidVectorTmsServiceForm.tsx
+++ b/assets/entrepot/pages/service/tms/PyramidVectorTmsServiceForm/PyramidVectorTmsServiceForm.tsx
@@ -15,6 +15,7 @@ import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
 import Wait from "../../../../../components/Utils/Wait";
 import useScrollToTopEffect from "../../../../../hooks/useScrollToTopEffect";
+import useServiceQuery from "../../../../../hooks/queries/useServiceQuery";
 import { useTranslation } from "../../../../../i18n/i18n";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
 import { CartesApiException } from "../../../../../modules/jsonFetch";
@@ -118,14 +119,7 @@ const PyramidVectorTmsServiceForm: FC<PyramidVectorTmsServiceFormProps> = ({ dat
         enabled: !(createServiceMutation.isPending || editServiceMutation.isPending),
     });
 
-    const offeringQuery = useQuery<Service | null, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId ?? "xxxx"),
-        queryFn: ({ signal }) => {
-            if (offeringId) {
-                return api.service.getService(datastoreId, offeringId, { signal });
-            }
-            return Promise.resolve(null);
-        },
+    const offeringQuery = useServiceQuery(datastoreId, offeringId ?? "xxxx", {
         enabled: editMode && !(createServiceMutation.isPending || editServiceMutation.isPending),
         staleTime: Infinity,
     });

--- a/assets/entrepot/pages/service/view/ServiceView.tsx
+++ b/assets/entrepot/pages/service/view/ServiceView.tsx
@@ -2,16 +2,13 @@ import { fr } from "@codegouvfr/react-dsfr";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useQuery } from "@tanstack/react-query";
 import { FC } from "react";
 
-import { OfferingStatusEnum, OfferingTypeEnum, type Service } from "../../../../@types/app";
+import { OfferingStatusEnum, OfferingTypeEnum } from "../../../../@types/app";
 import Main from "../../../../components/Layout/Main";
 import LoadingText from "../../../../components/Utils/LoadingText";
-import RQKeys from "../../../../modules/entrepot/RQKeys";
-import { type CartesApiException } from "../../../../modules/jsonFetch";
+import useServiceQuery from "../../../../hooks/queries/useServiceQuery";
 import { routes } from "../../../../router/router";
-import api from "../../../api";
 import PrivateServiceExplanation from "./PrivateServiceExplanation";
 import ServiceViewContent from "./ServiceViewContent";
 
@@ -24,11 +21,7 @@ type ServiceViewProps = {
 };
 
 const ServiceView: FC<ServiceViewProps> = ({ datastoreId, offeringId, datasheetName }) => {
-    const serviceQuery = useQuery<Service, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId),
-        queryFn: ({ signal }) => api.service.getService(datastoreId, offeringId, { signal }),
-        staleTime: 60000,
-    });
+    const serviceQuery = useServiceQuery(datastoreId, offeringId);
 
     return (
         <Main title={`Visualisation données ${datasheetName ?? serviceQuery.data?.layer_name}`}>

--- a/assets/entrepot/pages/service/view/ServiceViewContent.tsx
+++ b/assets/entrepot/pages/service/view/ServiceViewContent.tsx
@@ -1,13 +1,10 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import Tabs from "@codegouvfr/react-dsfr/Tabs";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-import { CartesStyle, OfferingTypeEnum, Service, StoredDataTypeEnum } from "@/@types/app";
+import { CartesStyle, OfferingTypeEnum, StoredDataTypeEnum } from "@/@types/app";
 import RMap from "@/components/Utils/RMap";
-import api from "@/entrepot/api";
-import RQKeys from "@/modules/entrepot/RQKeys";
-import { CartesApiException } from "@/modules/jsonFetch";
+import useServiceQuery from "@/hooks/queries/useServiceQuery";
 import getWebService from "@/modules/WebServices/WebServices";
 import BaseLayer from "ol/layer/Base";
 import ServiceShareInfo from "./ServiceShareInfo";
@@ -22,11 +19,7 @@ type ServiceViewContent = {
 function ServiceViewContent(props: ServiceViewContent) {
     const { datastoreId, offeringId, datasheetName } = props;
 
-    const serviceQuery = useQuery<Service, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId),
-        queryFn: ({ signal }) => api.service.getService(datastoreId, offeringId, { signal }),
-        staleTime: 60000,
-    });
+    const serviceQuery = useServiceQuery(datastoreId, offeringId);
 
     const { data: service } = serviceQuery;
 

--- a/assets/entrepot/pages/service/view/Style/StyleAddModifyForm.tsx
+++ b/assets/entrepot/pages/service/view/Style/StyleAddModifyForm.tsx
@@ -5,7 +5,7 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useMutation, useQueries, useQuery, useQueryClient, UseQueryOptions } from "@tanstack/react-query";
+import { useMutation, useQueries, useQueryClient, UseQueryOptions } from "@tanstack/react-query";
 import { FC, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
@@ -17,6 +17,7 @@ import LoadingIcon from "@/components/Utils/LoadingIcon";
 import LoadingText from "@/components/Utils/LoadingText";
 import Wait from "@/components/Utils/Wait";
 import { StyleFormProvider } from "@/contexts/StyleFormContext";
+import useServiceQuery from "@/hooks/queries/useServiceQuery";
 import TMSStyleTools from "@/modules/Style/TMSStyleFilesManager/TMSStyleTools";
 import { routes } from "@/router/router";
 import { decodeKeys, encodeKey, encodeKeys, getFileExtension, removeDiacritics } from "@/utils";
@@ -133,11 +134,7 @@ const StyleAddModifyForm: FC<StyleAddModifyFormProps> = (props) => {
 
     const queryClient = useQueryClient();
 
-    const serviceQuery = useQuery<Service, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId),
-        queryFn: ({ signal }) => api.service.getService(datastoreId, offeringId, { signal }),
-        staleTime: 600000,
-    });
+    const serviceQuery = useServiceQuery(datastoreId, offeringId, { staleTime: 600000 });
     const { data: service } = serviceQuery;
 
     const styles: CartesStyle[] = useMemo(() => service?.configuration.styles ?? [], [service]);

--- a/assets/entrepot/pages/service/wfs/WfsServiceForm.tsx
+++ b/assets/entrepot/pages/service/wfs/WfsServiceForm.tsx
@@ -18,6 +18,7 @@ import LoadingText from "../../../../components/Utils/LoadingText";
 import Wait from "../../../../components/Utils/Wait";
 import { filterGeometricRelations } from "../../../../helpers";
 import useScrollToTopEffect from "../../../../hooks/useScrollToTopEffect";
+import useServiceQuery from "../../../../hooks/queries/useServiceQuery";
 import { useTranslation } from "../../../../i18n/i18n";
 import RQKeys from "../../../../modules/entrepot/RQKeys";
 import { CartesApiException } from "../../../../modules/jsonFetch";
@@ -178,14 +179,7 @@ const WfsServiceForm: FC<WfsServiceFormProps> = ({ datastoreId, vectorDbId, offe
         enabled: !(createServiceMutation.isPending || editServiceMutation.isPending),
     });
 
-    const offeringQuery = useQuery<Service | null, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId ?? "xxxx"),
-        queryFn: ({ signal }) => {
-            if (offeringId) {
-                return api.service.getService(datastoreId, offeringId, { signal });
-            }
-            return Promise.resolve(null);
-        },
+    const offeringQuery = useServiceQuery(datastoreId, offeringId ?? "xxxx", {
         enabled: editMode && !(createServiceMutation.isPending || editServiceMutation.isPending),
         staleTime: Infinity,
     });

--- a/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterGenerateForm/PyramidRasterGenerateForm.tsx
+++ b/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterGenerateForm/PyramidRasterGenerateForm.tsx
@@ -2,22 +2,24 @@ import { fr } from "@codegouvfr/react-dsfr";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import Button from "@codegouvfr/react-dsfr/Button";
 import ButtonsGroup from "@codegouvfr/react-dsfr/ButtonsGroup";
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Stepper from "@codegouvfr/react-dsfr/Stepper";
-import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FC, useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import * as yup from "yup";
 
-import type { PyramidRaster, Service } from "../../../../../@types/app";
+import type { PyramidRaster } from "../../../../../@types/app";
 import type { ConfigurationWmsVectorDetailsContent } from "../../../../../@types/entrepot";
+import Main from "../../../../../components/Layout/Main";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
 import Wait from "../../../../../components/Utils/Wait";
 import ZoomRange from "../../../../../components/Utils/ZoomRange";
 import olDefaults from "../../../../../data/ol-defaults.json";
+import useServiceQuery from "../../../../../hooks/queries/useServiceQuery";
 import useScrollToTopEffect from "../../../../../hooks/useScrollToTopEffect";
 import { useTranslation } from "../../../../../i18n/i18n";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
@@ -26,7 +28,6 @@ import { routes } from "../../../../../router/router";
 import { bboxToWkt } from "../../../../../utils";
 import api from "../../../../api";
 import { DatasheetViewActiveTabEnum } from "../../../datasheet/DatasheetView/DatasheetView/DatasheetView";
-import Main from "../../../../../components/Layout/Main";
 
 const STEPS = {
     TECHNICAL_NAME: 1,
@@ -50,11 +51,7 @@ const PyramidRasterGenerateForm: FC<PyramidRasterGenerateFormProps> = ({ datasto
 
     const [currentStep, setCurrentStep] = useState(STEPS.TECHNICAL_NAME);
 
-    const serviceQuery = useQuery<Service, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId),
-        queryFn: () => api.service.getService(datastoreId, offeringId),
-        staleTime: 60000,
-    });
+    const serviceQuery = useServiceQuery(datastoreId, offeringId);
 
     const queryClient = useQueryClient();
 

--- a/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterWmsRasterServiceForm/PyramidRasterWmsRasterServiceForm.tsx
+++ b/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterWmsRasterServiceForm/PyramidRasterWmsRasterServiceForm.tsx
@@ -15,6 +15,7 @@ import Main from "../../../../../components/Layout/Main";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
 import Wait from "../../../../../components/Utils/Wait";
+import useServiceQuery from "../../../../../hooks/queries/useServiceQuery";
 import useScrollToTopEffect from "../../../../../hooks/useScrollToTopEffect";
 import { useTranslation } from "../../../../../i18n/i18n";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
@@ -102,14 +103,7 @@ const PyramidRasterWmsRasterServiceForm: FC<PyramidRasterWmsRasterServiceFormPro
         enabled: !(createServiceMutation.isPending || editServiceMutation.isPending),
     });
 
-    const offeringQuery = useQuery<Service | null, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId ?? "xxxx"),
-        queryFn: ({ signal }) => {
-            if (offeringId) {
-                return api.service.getService(datastoreId, offeringId, { signal });
-            }
-            return Promise.resolve(null);
-        },
+    const offeringQuery = useServiceQuery(datastoreId, offeringId ?? "xxxx", {
         enabled: editMode && !(createServiceMutation.isPending || editServiceMutation.isPending),
         staleTime: Infinity,
     });

--- a/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterWmtsServiceForm/PyramidRasterWmtsServiceForm.tsx
+++ b/assets/entrepot/pages/service/wms-raster-wmts/PyramidRasterWmtsServiceForm/PyramidRasterWmtsServiceForm.tsx
@@ -15,6 +15,7 @@ import Main from "../../../../../components/Layout/Main";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
 import Wait from "../../../../../components/Utils/Wait";
+import useServiceQuery from "../../../../../hooks/queries/useServiceQuery";
 import useScrollToTopEffect from "../../../../../hooks/useScrollToTopEffect";
 import { useTranslation } from "../../../../../i18n/i18n";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
@@ -102,14 +103,7 @@ const PyramidRasterWmtsServiceForm: FC<PyramidRasterWmtsServiceFormProps> = ({ d
         enabled: !(createServiceMutation.isPending || editServiceMutation.isPending),
     });
 
-    const offeringQuery = useQuery<Service | null, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId ?? "xxxx"),
-        queryFn: ({ signal }) => {
-            if (offeringId) {
-                return api.service.getService(datastoreId, offeringId, { signal });
-            }
-            return Promise.resolve(null);
-        },
+    const offeringQuery = useServiceQuery(datastoreId, offeringId ?? "xxxx", {
         enabled: editMode && !(createServiceMutation.isPending || editServiceMutation.isPending),
         staleTime: Infinity,
     });

--- a/assets/entrepot/pages/service/wms-vector/WmsVectorServiceForm.tsx
+++ b/assets/entrepot/pages/service/wms-vector/WmsVectorServiceForm.tsx
@@ -26,6 +26,7 @@ import Main from "../../../../components/Layout/Main";
 import LoadingIcon from "../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../components/Utils/LoadingText";
 import Wait from "../../../../components/Utils/Wait";
+import useServiceQuery from "../../../../hooks/queries/useServiceQuery";
 import useScrollToTopEffect from "../../../../hooks/useScrollToTopEffect";
 import { useTranslation } from "../../../../i18n/i18n";
 import RQKeys from "../../../../modules/entrepot/RQKeys";
@@ -192,14 +193,7 @@ const WmsVectorServiceForm: FC<WmsVectorServiceFormProps> = ({ datastoreId, vect
         enabled: currentStep === STEPS.METADATAS_DESCRIPTION && !(createServiceMutation.isPending || editServiceMutation.isPending),
     });
 
-    const offeringQuery = useQuery<Service | null, CartesApiException>({
-        queryKey: RQKeys.datastore_offering(datastoreId, offeringId ?? "xxxx"),
-        queryFn: ({ signal }) => {
-            if (offeringId) {
-                return api.service.getService(datastoreId, offeringId, { signal });
-            }
-            return Promise.resolve(null);
-        },
+    const offeringQuery = useServiceQuery(datastoreId, offeringId ?? "xxxx", {
         enabled: editMode && !(createServiceMutation.isPending || editServiceMutation.isPending),
         staleTime: Infinity,
     });

--- a/assets/hooks/queries/useServiceQuery.tsx
+++ b/assets/hooks/queries/useServiceQuery.tsx
@@ -1,0 +1,20 @@
+import { UndefinedInitialDataOptions, useQuery } from "@tanstack/react-query";
+
+import { delta } from "@/utils";
+import type { Service } from "../../@types/app";
+import api from "../../entrepot/api";
+import RQKeys from "../../modules/entrepot/RQKeys";
+import { type CartesApiException } from "../../modules/jsonFetch";
+
+export default function useServiceQuery(
+    datastoreId: string,
+    offeringId: string,
+    otherOptions?: Partial<UndefinedInitialDataOptions<Service, CartesApiException>>
+) {
+    return useQuery<Service, CartesApiException>({
+        queryKey: RQKeys.datastore_offering(datastoreId, offeringId),
+        queryFn: ({ signal }) => api.service.getService(datastoreId, offeringId, { signal }),
+        staleTime: delta.minutes(1),
+        ...otherOptions,
+    });
+}


### PR DESCRIPTION
la structure de fiche de données contient déjà toutes les infos des services, donc on les utilise pour préremplir les query service comme ça pas de requête dans la page de visu des services