### PR TITLE
feat: ajout QueryParams, amélioration typage SymfonyRouting.generate

### DIFF
--- a/assets/entrepot/api/annexe.ts
+++ b/assets/entrepot/api/annexe.ts
@@ -1,9 +1,9 @@
 import { AnnexStandardListResponseDto } from "@/@types/entrepot";
 import { Annexe, DatasheetThumbnailAnnexe } from "../../@types/app";
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { apiFetch, jsonFetch } from "../../modules/jsonFetch";
 
-const getList = async (datastoreId: string, query: object = {}, otherOptions: RequestInit = {}) => {
+const getList = async (datastoreId: string, query: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_annexe_get_list", { datastoreId, ...query });
     const res = await apiFetch(url, {
         ...otherOptions,

--- a/assets/entrepot/api/datastore.ts
+++ b/assets/entrepot/api/datastore.ts
@@ -1,5 +1,5 @@
 import type { Datastore, DatastoreEndpoint, DatastorePermission } from "../../@types/app";
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { jsonFetch } from "../../modules/jsonFetch";
 
 const get = (datastoreId: string, otherOptions: RequestInit = {}) => {
@@ -30,7 +30,7 @@ const getPermission = (datastoreId: string, permissionId: string, otherOptions: 
     });
 };
 
-const getPermissions = (datastoreId: string, query: object, otherOptions: RequestInit = {}) => {
+const getPermissions = (datastoreId: string, query: QueryParams, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_datastore_get_permissions", { datastoreId, ...query });
     return jsonFetch<DatastorePermission[]>(url, {
         ...otherOptions,

--- a/assets/entrepot/api/metadata.ts
+++ b/assets/entrepot/api/metadata.ts
@@ -1,8 +1,8 @@
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { jsonFetch } from "../../modules/jsonFetch";
 import { Metadata } from "../../@types/app";
 
-const add = (datastoreId: string, body: object, queryParams: object = {}) => {
+const add = (datastoreId: string, body: object, queryParams: QueryParams = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_metadata_add", { datastoreId, ...queryParams });
     return jsonFetch(
         url,
@@ -13,7 +13,7 @@ const add = (datastoreId: string, body: object, queryParams: object = {}) => {
     );
 };
 
-const getList = (datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getList = (datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_metadata_get_list", { datastoreId, ...queryParams });
     return jsonFetch<Omit<Metadata, "csw_metadata">[]>(url, {
         method: "GET",

--- a/assets/entrepot/api/processing.ts
+++ b/assets/entrepot/api/processing.ts
@@ -1,9 +1,9 @@
 import { ProcessingExecution } from "@/@types/app";
 import { ProcessingListResponseDto } from "@/@types/entrepot";
 import { jsonFetch } from "@/modules/jsonFetch";
-import SymfonyRouting from "@/modules/Routing";
+import SymfonyRouting, { type QueryParams } from "@/modules/Routing";
 
-const getList = (datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getList = (datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_processing_get_list", { datastoreId, ...queryParams });
     return jsonFetch<ProcessingListResponseDto[]>(url, {
         ...otherOptions,
@@ -11,7 +11,7 @@ const getList = (datastoreId: string, queryParams: object = {}, otherOptions: Re
 };
 
 // exécutions de traitements
-const getExecutionList = (datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getExecutionList = (datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_processing_execution_get_list", { datastoreId, ...queryParams });
     return jsonFetch<ProcessingExecution[]>(url, {
         ...otherOptions,

--- a/assets/entrepot/api/service.ts
+++ b/assets/entrepot/api/service.ts
@@ -1,6 +1,6 @@
 import type { OfferingStandardListResponseDto } from "@/@types/entrepot";
 import { jsonFetch } from "@/modules/jsonFetch";
-import SymfonyRouting, { QueryParams } from "@/modules/Routing";
+import SymfonyRouting, { type QueryParams } from "@/modules/Routing";
 import { ConfigurationTypeEnum, OfferingTypeEnum, type Service } from "../../@types/app";
 
 const getService = (datastoreId: string, offeringId: string, otherOptions: RequestInit = {}) => {

--- a/assets/entrepot/api/service.ts
+++ b/assets/entrepot/api/service.ts
@@ -1,6 +1,6 @@
 import type { OfferingStandardListResponseDto } from "@/@types/entrepot";
 import { jsonFetch } from "@/modules/jsonFetch";
-import SymfonyRouting from "@/modules/Routing";
+import SymfonyRouting, { QueryParams } from "@/modules/Routing";
 import { ConfigurationTypeEnum, OfferingTypeEnum, type Service } from "../../@types/app";
 
 const getService = (datastoreId: string, offeringId: string, otherOptions: RequestInit = {}) => {
@@ -10,7 +10,7 @@ const getService = (datastoreId: string, offeringId: string, otherOptions: Reque
     });
 };
 
-const getOfferings = <T = OfferingStandardListResponseDto>(datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getOfferings = <T = OfferingStandardListResponseDto>(datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_service_get_offerings_list", { datastoreId, ...queryParams });
     return jsonFetch<T[]>(url, {
         ...otherOptions,

--- a/assets/entrepot/api/statics.ts
+++ b/assets/entrepot/api/statics.ts
@@ -1,8 +1,8 @@
 import { StaticFile } from "@/@types/app";
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { apiFetch, jsonFetch } from "../../modules/jsonFetch";
 
-const getList = async (datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getList = async (datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_statics_get_list", { datastoreId, ...queryParams });
     const res = await apiFetch(url, {
         ...otherOptions,
@@ -14,7 +14,7 @@ const getList = async (datastoreId: string, queryParams: object = {}, otherOptio
     };
 };
 
-const getAll = (datastoreId: string, queryParams: object = {}, otherOptions: RequestInit = {}) => {
+const getAll = (datastoreId: string, queryParams: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_statics_get_list", { datastoreId, ...queryParams, all: true });
     return jsonFetch<StaticFile[]>(url, {
         method: "GET",

--- a/assets/entrepot/api/stored-data.ts
+++ b/assets/entrepot/api/stored-data.ts
@@ -1,9 +1,9 @@
 import { Offering, StoredData, StoredDataReport } from "../../@types/app";
 import { ProcessingExecutionStoredDataDto } from "../../@types/entrepot";
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { apiFetch, jsonFetch } from "../../modules/jsonFetch";
 
-const getList = async <T = StoredData[]>(datastoreId: string, query: object = {}, otherOptions: RequestInit = {}) => {
+const getList = async <T = StoredData[]>(datastoreId: string, query: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_stored_data_get_list", { datastoreId, ...query });
     const res = await apiFetch(url, {
         ...otherOptions,
@@ -15,7 +15,7 @@ const getList = async <T = StoredData[]>(datastoreId: string, query: object = {}
     };
 };
 
-const getAll = async <T = StoredData[]>(datastoreId: string, query: object = {}, otherOptions: RequestInit = {}) => {
+const getAll = async <T = StoredData[]>(datastoreId: string, query: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_stored_data_get_list", { datastoreId, all: true, ...query });
     return jsonFetch<T>(url, {
         ...otherOptions,

--- a/assets/entrepot/api/upload.ts
+++ b/assets/entrepot/api/upload.ts
@@ -1,9 +1,9 @@
-import SymfonyRouting from "../../modules/Routing";
+import SymfonyRouting, { type QueryParams } from "../../modules/Routing";
 import { apiFetch, jsonFetch } from "../../modules/jsonFetch";
 import { UploadReport } from "../../@types/app";
 import { Upload, UploadTree } from "../../@types/app";
 
-const getList = async (datastoreId: string, query: object = {}, otherOptions: RequestInit = {}) => {
+const getList = async (datastoreId: string, query: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_upload_get_list", { datastoreId, ...query });
     const res = await apiFetch(url, {
         ...otherOptions,
@@ -15,7 +15,7 @@ const getList = async (datastoreId: string, query: object = {}, otherOptions: Re
     };
 };
 
-const getAll = async (datastoreId: string, query: object = {}, otherOptions: RequestInit = {}) => {
+const getAll = async (datastoreId: string, query: QueryParams = {}, otherOptions: RequestInit = {}) => {
     const url = SymfonyRouting.generate("cartesgouvfr_api_upload_get_list", { datastoreId, all: true, ...query });
     return jsonFetch<Upload[]>(url, {
         ...otherOptions,

--- a/assets/entrepot/pages/datastore/ManagePermissions/AddPermissionForm.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/AddPermissionForm.tsx
@@ -60,7 +60,7 @@ const AddPermissionForm: FC<AddPermissionFormProps> = ({ datastoreId }) => {
         data,
     } = useQuery({
         queryKey: RQKeys.datastore_offering_list(datastoreId),
-        queryFn: ({ signal }) => api.service.getOfferings(datastoreId, { signal }),
+        queryFn: ({ signal }) => api.service.getOfferings(datastoreId, {}, { signal }),
         staleTime: 30000,
     });
 

--- a/assets/entrepot/pages/datastore/ManagePermissions/EditPermissionForm.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/EditPermissionForm.tsx
@@ -41,7 +41,7 @@ const EditPermissionForm: FC<EditPermissionFormProps> = ({ datastoreId, permissi
     /* Liste des offerings */
     const offeringsQuery = useQuery({
         queryKey: RQKeys.datastore_offering_list(datastoreId),
-        queryFn: ({ signal }) => api.service.getOfferings(datastoreId, { signal }),
+        queryFn: ({ signal }) => api.service.getOfferings(datastoreId, {}, { signal }),
         staleTime: 30000,
     });
 

--- a/assets/entrepot/pages/datastore/ManageStorage/storages/AnnexeUsage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/storages/AnnexeUsage.tsx
@@ -7,6 +7,7 @@ import { FC, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CartesApiException } from "@/modules/jsonFetch";
+import { type QueryParams } from "@/modules/Routing";
 import { Annexe, Datastore } from "../../../../../@types/app";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
@@ -30,12 +31,13 @@ const confirmDialogModal = createModal({
     isOpenedByDefault: false,
 });
 
-async function fetchAnnexeList(datastoreId: string, queryParams: object = {}, signal?: AbortSignal) {
+async function fetchAnnexeList(datastoreId: string, queryParams: QueryParams = {}, signal?: AbortSignal) {
     const res = await api.annexe.getList(datastoreId, queryParams, { signal });
+    const limit = typeof queryParams["limit"] === "number" ? queryParams["limit"] : 10;
 
     return {
         items: res.data,
-        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", queryParams?.["limit"] ?? 10),
+        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", limit),
     };
 }
 

--- a/assets/entrepot/pages/datastore/ManageStorage/storages/StaticsUsage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/storages/StaticsUsage.tsx
@@ -7,6 +7,7 @@ import { FC, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CartesApiException } from "@/modules/jsonFetch";
+import { type QueryParams } from "@/modules/Routing";
 import { routes, useRoutePaginationParams } from "@/router/router";
 import type { Datastore, StaticFile } from "../../../../../@types/app";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
@@ -28,12 +29,13 @@ type StaticsUsageProps = {
     datastore: Datastore;
 };
 
-async function fetchStaticsList(datastoreId: string, queryParams: object = {}, signal?: AbortSignal) {
+async function fetchStaticsList(datastoreId: string, queryParams: QueryParams = {}, signal?: AbortSignal) {
     const res = await api.statics.getList(datastoreId, queryParams, { signal });
+    const limit = typeof queryParams["limit"] === "number" ? queryParams["limit"] : 10;
 
     return {
         items: res.data,
-        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", queryParams?.["limit"] ?? 10),
+        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", limit),
     };
 }
 

--- a/assets/entrepot/pages/datastore/ManageStorage/storages/UploadUsage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/storages/UploadUsage.tsx
@@ -7,6 +7,7 @@ import { FC, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CartesApiException } from "@/modules/jsonFetch";
+import { type QueryParams } from "@/modules/Routing";
 import { Datastore, Upload } from "../../../../../@types/app";
 import LoadingIcon from "../../../../../components/Utils/LoadingIcon";
 import LoadingText from "../../../../../components/Utils/LoadingText";
@@ -25,12 +26,13 @@ const confirmDialogModal = createModal({
     isOpenedByDefault: false,
 });
 
-async function fetchUploadList(datastoreId: string, queryParams: object = {}, signal?: AbortSignal) {
+async function fetchUploadList(datastoreId: string, queryParams: QueryParams = {}, signal?: AbortSignal) {
     const res = await api.upload.getList(datastoreId, queryParams, { signal });
+    const limit = typeof queryParams["limit"] === "number" ? queryParams["limit"] : 10;
 
     return {
         items: res.data,
-        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", queryParams?.["limit"] ?? 10),
+        contentRange: decodeContentRange(res.headers.get("content-range") ?? "", limit),
     };
 }
 

--- a/assets/hooks/queries/useStoredDataListQuery.tsx
+++ b/assets/hooks/queries/useStoredDataListQuery.tsx
@@ -4,11 +4,12 @@ import { StoredData } from "@/@types/app";
 import api from "@/entrepot/api";
 import RQKeys from "@/modules/entrepot/RQKeys";
 import { CartesApiException } from "@/modules/jsonFetch";
+import { type QueryParams } from "@/modules/Routing";
 import { delta } from "@/utils";
 
 export default function useStoredDataListQuery(
     datastoreId: string,
-    queryParams: object = {},
+    queryParams: QueryParams = {},
     otherOptions?: Partial<UndefinedInitialDataOptions<StoredData[], CartesApiException>>
 ) {
     return useQuery<StoredData[], CartesApiException>({

--- a/assets/modules/Routing.ts
+++ b/assets/modules/Routing.ts
@@ -4,3 +4,6 @@ Routing.setRoutingData(routes);
 
 const SymfonyRouting = Routing;
 export default SymfonyRouting;
+
+export type QueryParamPrimitive = string | number | boolean | null | undefined;
+export type QueryParams = Record<string, QueryParamPrimitive | readonly QueryParamPrimitive[]>;

--- a/assets/modules/entrepot/RQKeys.ts
+++ b/assets/modules/entrepot/RQKeys.ts
@@ -1,4 +1,5 @@
 import { ConfigurationTypeEnum, OfferingTypeEnum } from "../../@types/app";
+import { type QueryParams } from "../Routing";
 
 /**
  * Factory pour créer des query keys pour react-query
@@ -11,7 +12,7 @@ const RQKeys = {
     datastore_permission_offering: (datastoreId: string, offeringId: string): string[] => ["datastore", datastoreId, "permissions", "offering", offeringId],
     datastore_permission: (datastoreId: string, permissionId: string): string[] => ["datastore", datastoreId, "permission", permissionId],
 
-    datastore_upload_list: (datastoreId: string, queryParams?: object): string[] => {
+    datastore_upload_list: (datastoreId: string, queryParams?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "upload"];
         if (queryParams) keys.push(JSON.stringify(queryParams));
         return keys;
@@ -21,7 +22,7 @@ const RQKeys = {
     datastore_upload_file_tree: (datastoreId: string, uploadId: string = "undefined"): string[] => ["datastore", datastoreId, "upload", uploadId, "file_tree"],
     datastore_upload_report: (datastoreId: string, uploadId: string): string[] => ["datastore", datastoreId, "upload", uploadId, "report"],
 
-    datastore_stored_data_list: (datastoreId: string, queryParams?: object): string[] => {
+    datastore_stored_data_list: (datastoreId: string, queryParams?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "stored_data"];
         if (queryParams) keys.push(JSON.stringify(queryParams));
         return keys;
@@ -30,7 +31,7 @@ const RQKeys = {
     datastore_stored_data_uses: (datastoreId: string, storedDataId: string): string[] => ["datastore", datastoreId, "stored_data", storedDataId, "uses"],
     datastore_stored_data_report: (datastoreId: string, storedDataId: string): string[] => ["datastore", datastoreId, "stored_data", storedDataId, "report"],
 
-    datastore_processing_execution_list: (datastoreId: string, queryParams?: object): string[] => {
+    datastore_processing_execution_list: (datastoreId: string, queryParams?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "processing", "executions"];
         if (queryParams) keys.push(JSON.stringify(queryParams));
         return keys;
@@ -41,7 +42,7 @@ const RQKeys = {
     datastore_datasheet_metadata: (datastoreId: string, datasheetName: string): string[] => ["datastore", datastoreId, "datasheet", datasheetName, "metadata"],
     datastore_datasheet_service_list: (datastoreId: string, datasheetName: string) => ["datastore", datastoreId, "datasheet", datasheetName, "services"],
 
-    datastore_offering_list: (datastoreId: string, queryParams?: object): string[] => {
+    datastore_offering_list: (datastoreId: string, queryParams?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "offering"];
         if (queryParams) keys.push(JSON.stringify(queryParams));
         return keys;
@@ -57,7 +58,7 @@ const RQKeys = {
 
     datastore_offering: (datastoreId: string, offeringId: string): string[] => ["datastore", datastoreId, "offering", offeringId],
 
-    datastore_annexe_list: (datastoreId: string, queryParams?: object): string[] => {
+    datastore_annexe_list: (datastoreId: string, queryParams?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "annexe"];
         if (queryParams) keys.push(JSON.stringify(queryParams));
         return keys;
@@ -67,7 +68,7 @@ const RQKeys = {
     datastore_metadata_list: (datastoreId: string): string[] => ["datastore", datastoreId, "metadata"],
     datastore_metadata_by_id: (datastoreId: string, metadataId: string): string[] => ["datastore", datastoreId, "metadata", metadataId],
 
-    datastore_statics_list: (datastoreId: string, query?: unknown): string[] => {
+    datastore_statics_list: (datastoreId: string, query?: QueryParams): string[] => {
         const keys = ["datastore", datastoreId, "statics"];
         if (query) keys.push(JSON.stringify(query));
         return keys;


### PR DESCRIPTION
Pourquoi ?

`queryParams` est présent dans beaucoup de fonctions `api.xxx.yyy` pour générer les URLs backend avec `SymfonyRouting`, mais il était typé parfois `object` ou  `unknown` et jusque-là ça posait pas de soucis.

Récemment j'avais ajouté ce paramètre positionnel `queryParams` à la fonction `api.service.getOfferings` :
https://github.com/IGNF/cartes.gouv.fr/blob/3a0342e7de72b1b76714c290d7ed2d5f129a5a81/assets/entrepot/api/service.ts#L13

ce qui rend des appels existants à cette fonction faux mais le lint et le type-check ne l'ont pas signalé comme erreur :
https://github.com/IGNF/cartes.gouv.fr/blob/3a0342e7de72b1b76714c290d7ed2d5f129a5a81/assets/entrepot/pages/datastore/ManagePermissions/AddPermissionForm.tsx#L63
Et donc actuellement* les pages ajout/modif de permission de datastore plantent avec cette erreur : 
```
'throwIfAborted' called on an object that does not implement interface AbortSignal.
```
_*ça se plante pas forcément tout le temps, juste quand une requête est annulée par react-query_

Désormais grâce à ce nouveau type `QueryParams` on sera prévenu à l'avance de ce genre de cas.