### PR TITLE
feat: afficher juste type offering quand pas de permission #994

### DIFF
--- a/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
+++ b/assets/entrepot/pages/users/keys/UserKeysListTab/UserKeysListTab.tsx
@@ -291,7 +291,7 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                                 return (
                                                     <div key={type} className={fr.cx("fr-mb-5v")}>
                                                         {typeIndex >= 1 ? <hr /> : null}
-                                                        {services[0].permission && (
+                                                        {services[0].permission ? (
                                                             <div className={fr.cx("fr-col-12", "fr-col-lg-10")}>
                                                                 <UserKeyLink
                                                                     permissionId={services[0].permission._id}
@@ -299,6 +299,8 @@ const UserKeysListTab: FC<UserKeysListTabProps> = ({ keys, permissions }) => {
                                                                     hash={accessKey.type_infos && (accessKey.type_infos as HashInfoDto).hash}
                                                                 />
                                                             </div>
+                                                        ) : (
+                                                            <div className={fr.cx("fr-label", "fr-py-2v")}>{services[0].offering.type}</div>
                                                         )}
                                                         <div className={fr.cx("fr-mb-1v")}>{t("available_services")}</div>
                                                         <ul>


### PR DESCRIPTION
Affichage de juste le type d'offering quand on a un access sans permission.

En temps normal,
<img width="807" height="357" alt="image" src="https://github.com/user-attachments/assets/b49f1b3e-e4d0-4eef-84be-d71d820aec46" />

Si pas de permission,
<img width="815" height="299" alt="image" src="https://github.com/user-attachments/assets/fb73e278-381d-4fcf-95d9-7a7d47fc19df" />
