### PR TITLE
feat(logging): revue

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -145,6 +145,7 @@ COPY .docker/apache-security.conf /etc/apache2/conf-enabled/security.conf
 COPY .docker/apache-vhost.conf /etc/apache2/sites-available/000-default.conf
 
 RUN a2enmod rewrite remoteip
+RUN a2disconf other-vhosts-access-log
 
 #----------------------------------------------------------------------
 # Installer l'application pour production

--- a/.docker/apache-vhost.conf
+++ b/.docker/apache-vhost.conf
@@ -1,21 +1,24 @@
 <VirtualHost *:8000>
-    ServerName cartes.gouv.fr
-    DocumentRoot /opt/cartesgouvfr-site/public
+ServerName cartes.gouv.fr
+DocumentRoot /opt/cartesgouvfr-site/public
 
-    RedirectMatch 301 ^/$ /explorer-les-cartes
-    RedirectMatch 301 ^/faq/?$ /aide/fr
-    RedirectMatch 301 ^/a-propos/?$ /decouvrir
-    RedirectMatch 301 ^/nous-ecrire/?$ /aide/fr/nous-ecrire
-    RedirectMatch 301 ^/offre/?$ /offres
+RedirectMatch 301 ^/$ /explorer-les-cartes
+RedirectMatch 301 ^/faq/?$ /aide/fr
+RedirectMatch 301 ^/a-propos/?$ /decouvrir
+RedirectMatch 301 ^/nous-ecrire/?$ /aide/fr/nous-ecrire
+RedirectMatch 301 ^/offre/?$ /offres
 
-    <Directory "/opt/cartesgouvfr-site/public">
-        Options -Indexes +FollowSymLinks +MultiViews
-        AllowOverride All
+<Directory "/opt/cartesgouvfr-site/public">
+Options -Indexes +FollowSymLinks +MultiViews
+AllowOverride All
 
-        Require all granted
-    </Directory>
+Require all granted
+</Directory>
 
-    SetEnvIf User-Agent "^kube-probe" dontlog
-    ErrorLog ${APACHE_LOG_DIR}/error.log
-    CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog
-</VirtualHost>
+SetEnvIf User-Agent "^kube-probe" dontlog
+LogFormat "{\"timestamp\":\"% {
+    %Y-%m-%dT%H:%M:%S%
+}
+t\#$#%#$#placeholder23434#$#%#$#remote_ip\#$#%#$#placeholder33434#$#%#$#%a\#$#%#$#placeholder43434#$#%#$#method\#$#%#$#placeholder53434#$#%#$#%m\#$#%#$#placeholder63434#$#%#$#path\#$#%#$#placeholder73434#$#%#$#%U\#$#%#$#placeholder83434#$#%#$#query\#$#%#$#placeholder93434#$#%#$#%q\#$#%#$#placeholder103434#$#%#$#protocol\#$#%#$#placeholder113434#$#%#$#%H\#$#%#$#placeholder123434#$#%#$#status\#$#%#$#placeholder133434#$#%#$#bytes\#$#%#$#placeholder143434#$#%#$#referer\#$#%#$#placeholder153434#$#%#$#%{Referer}i\#$#%#$#placeholder163434#$#%#$#user_agent\#$#%#$#placeholder173434#$#%#$#%{User-agent}i\#$#%#$#placeholder183434#$#%#$#request_time_us\#$#%#$#placeholder193434#$#%#$# json
+ErrorLogFormat "{\"timestamp\":\"% {
+    %Y-%m-%dT%H:%M:%S%

--- a/.docker/apache-vhost.conf
+++ b/.docker/apache-vhost.conf
@@ -1,24 +1,22 @@
 <VirtualHost *:8000>
-ServerName cartes.gouv.fr
-DocumentRoot /opt/cartesgouvfr-site/public
+    ServerName cartes.gouv.fr
+    DocumentRoot /opt/cartesgouvfr-site/public
 
-RedirectMatch 301 ^/$ /explorer-les-cartes
-RedirectMatch 301 ^/faq/?$ /aide/fr
-RedirectMatch 301 ^/a-propos/?$ /decouvrir
-RedirectMatch 301 ^/nous-ecrire/?$ /aide/fr/nous-ecrire
-RedirectMatch 301 ^/offre/?$ /offres
+    RedirectMatch 301 ^/$ /explorer-les-cartes
+    RedirectMatch 301 ^/faq/?$ /aide/fr
+    RedirectMatch 301 ^/a-propos/?$ /decouvrir
+    RedirectMatch 301 ^/nous-ecrire/?$ /aide/fr/nous-ecrire
+    RedirectMatch 301 ^/offre/?$ /offres
 
-<Directory "/opt/cartesgouvfr-site/public">
-Options -Indexes +FollowSymLinks +MultiViews
-AllowOverride All
+    <Directory "/opt/cartesgouvfr-site/public">
+        Options -Indexes +FollowSymLinks +MultiViews
+        AllowOverride All
+        Require all granted
+    </Directory>
 
-Require all granted
-</Directory>
-
-SetEnvIf User-Agent "^kube-probe" dontlog
-LogFormat "{\"timestamp\":\"% {
-    %Y-%m-%dT%H:%M:%S%
-}
-t\#$#%#$#placeholder23434#$#%#$#remote_ip\#$#%#$#placeholder33434#$#%#$#%a\#$#%#$#placeholder43434#$#%#$#method\#$#%#$#placeholder53434#$#%#$#%m\#$#%#$#placeholder63434#$#%#$#path\#$#%#$#placeholder73434#$#%#$#%U\#$#%#$#placeholder83434#$#%#$#query\#$#%#$#placeholder93434#$#%#$#%q\#$#%#$#placeholder103434#$#%#$#protocol\#$#%#$#placeholder113434#$#%#$#%H\#$#%#$#placeholder123434#$#%#$#status\#$#%#$#placeholder133434#$#%#$#bytes\#$#%#$#placeholder143434#$#%#$#referer\#$#%#$#placeholder153434#$#%#$#%{Referer}i\#$#%#$#placeholder163434#$#%#$#user_agent\#$#%#$#placeholder173434#$#%#$#%{User-agent}i\#$#%#$#placeholder183434#$#%#$#request_time_us\#$#%#$#placeholder193434#$#%#$# json
-ErrorLogFormat "{\"timestamp\":\"% {
-    %Y-%m-%dT%H:%M:%S%
+    SetEnvIf User-Agent "^kube-probe" dontlog
+    LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S%z}t\",\"remote_ip\":\"%a\",\"method\":\"%m\",\"path\":\"%U\",\"query\":\"%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes\":%B,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-agent}i\",\"request_time_us\":%D}" json
+    ErrorLogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S%z}t\",\"module\":\"%m\",\"level\":\"%l\",\"pid\":%P,\"client\":\"%a\",\"message\":\"%M\"}"
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log json env=!dontlog
+</VirtualHost>

--- a/.docker/apache-vhost.conf
+++ b/.docker/apache-vhost.conf
@@ -14,9 +14,9 @@
         Require all granted
     </Directory>
 
-    SetEnvIf User-Agent "^kube-probe" dontlog
-    LogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S%z}t\",\"remote_ip\":\"%a\",\"method\":\"%m\",\"path\":\"%U\",\"query\":\"%q\",\"protocol\":\"%H\",\"status\":%>s,\"bytes\":%B,\"referer\":\"%{Referer}i\",\"user_agent\":\"%{User-agent}i\",\"request_time_us\":%D}" json
-    ErrorLogFormat "{\"timestamp\":\"%{%Y-%m-%dT%H:%M:%S%z}t\",\"module\":\"%m\",\"level\":\"%l\",\"pid\":%P,\"client\":\"%a\",\"message\":\"%M\"}"
+    SetEnvIfExpr "%{REQUEST_URI} =~ m#^/tableau-de-bord/health/?$#" dontlog
+    LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D" plain
+    ErrorLogFormat "[%{u}t] [%l] [pid %P] [client %a] %M"
     ErrorLog ${APACHE_LOG_DIR}/error.log
-    CustomLog ${APACHE_LOG_DIR}/access.log json env=!dontlog
+    CustomLog ${APACHE_LOG_DIR}/access.log plain env=!dontlog
 </VirtualHost>

--- a/.docker/apache-vhost.conf
+++ b/.docker/apache-vhost.conf
@@ -15,6 +15,8 @@
     </Directory>
 
     SetEnvIfExpr "%{REQUEST_URI} =~ m#^/tableau-de-bord/health/?$#" dontlog
+    SetEnvIfExpr "%{THE_REQUEST} =~ m#^OPTIONS\\s+\\*\\s+HTTP/# && req('User-Agent') =~ m#internal dummy connection#i" dontlog
+
     LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D" plain
     ErrorLogFormat "[%{u}t] [%l] [pid %P] [client %a] %M"
     ErrorLog ${APACHE_LOG_DIR}/error.log

--- a/.docker/apache-vhost.conf
+++ b/.docker/apache-vhost.conf
@@ -17,7 +17,7 @@
     SetEnvIfExpr "%{REQUEST_URI} =~ m#^/tableau-de-bord/health/?$#" dontlog
     SetEnvIfExpr "%{THE_REQUEST} =~ m#^OPTIONS\\s+\\*\\s+HTTP/# && req('User-Agent') =~ m#internal dummy connection#i" dontlog
 
-    LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %D" plain
+    LogFormat "\"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\" \"%{X-Forwarded-For}i\"" plain
     ErrorLogFormat "[%{u}t] [%l] [pid %P] [client %a] %M"
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log plain env=!dontlog

--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -17,6 +17,10 @@ realpath_cache_ttl=7200
 
 ; display_errors = Off
 ; display_startup_errors = Off
+display_errors = Off
+display_startup_errors = Off
+log_errors = On
+error_log = /proc/self/fd/2
 
 [opcache]
 opcache.enable=1

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/intl": "6.4.*",
         "symfony/mailer": "6.4.*",
         "symfony/mime": "6.4.*",
-        "symfony/monolog-bundle": "^3.0",
+        "symfony/monolog-bundle": "^3.11",
         "symfony/notifier": "6.4.*",
         "symfony/process": "6.4.*",
         "symfony/property-access": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1307,16 +1307,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -1334,7 +1334,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -1394,7 +1394,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -1406,7 +1406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "pentatrion/vite-bundle",

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -44,19 +44,23 @@ when@prod:
 
         handlers:
             main:
+                type: filter
+                handler: main_stdout
+                min_level: info
+                max_level: warning
+            main_stdout:
                 type: stream
                 path: php://stdout
-                level: info
-                formatter: monolog.formatter.logstash
-            mailer:
-                type: rotating_file
-                path: "%kernel.logs_dir%/mailer.log"
-                channels: mailer
-            nested:
+                formatter: monolog.formatter.json
+            errors_stderr:
                 type: stream
                 path: php://stderr
                 level: error
                 formatter: monolog.formatter.json
+            mailer:
+                type: rotating_file
+                path: "%kernel.logs_dir%/mailer.log"
+                channels: mailer
             console:
                 type: console
                 process_psr_3_messages: false
@@ -65,3 +69,4 @@ when@prod:
                 type: stream
                 channels: [deprecation]
                 path: php://stderr
+                formatter: monolog.formatter.json

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -8,16 +8,19 @@ when@dev:
             - mailer
 
         handlers:
+            # Journal principal de dev dans un fichier rotatif.
             main:
                 type: rotating_file
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
                 channels: ["!event"]
+            # Affiche les logs lors de l'exécution des commandes console.
             console:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!console"]
 
+            # Journal dedié aux messages du canal mailer en dev.
             mailer:
                 type: rotating_file
                 path: "%kernel.logs_dir%/mailer.log"
@@ -26,12 +29,14 @@ when@dev:
 when@test:
     monolog:
         handlers:
+            # Tamponne les logs et n'écrit que si une erreur survient.
             main:
                 type: fingers_crossed
                 action_level: error
                 handler: nested
                 excluded_http_codes: [404, 405]
                 channels: ["!event"]
+            # Destination de sortie du tampon de test vers un fichier.
             nested:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
@@ -40,30 +45,45 @@ when@test:
 when@prod:
     monolog:
         channels:
+            - deprecation
             - mailer
 
         handlers:
-            main:
+            # Filtre les niveaux notice à warning vers stdout (hors canaux dédiés).
+            stdout_notice_warning:
                 type: filter
-                handler: main_stdout
-                min_level: info
+                handler: stdout_stream
+                min_level: notice
                 max_level: warning
-            main_stdout:
+                channels: ["!deprecation", "!mailer"]
+
+            # Écrit les logs opérationnels sur stdout pour Kubernetes.
+            stdout_stream:
                 type: stream
                 path: php://stdout
-            errors_stderr:
+                channels: ["!deprecation", "!mailer"]
+
+            # Écrit les erreurs et niveaux supérieurs sur stderr.
+            stderr_error_plus:
                 type: stream
                 path: php://stderr
                 level: error
+                channels: ["!deprecation", "!mailer"]
+
+            # Isole les deprécations sur stderr via leur canal dédié.
+            deprecation:
+                type: stream
+                path: php://stderr
+                channels: [deprecation]
+
+            # Conserve les logs mailer dans un fichier rotatif specifique.
             mailer:
                 type: rotating_file
                 path: "%kernel.logs_dir%/mailer.log"
-                channels: mailer
+                channels: [mailer]
+
+            # Gère l'affichage des logs pour les commandes console en prod.
             console:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine"]
-            deprecation:
-                type: stream
-                channels: [deprecation]
-                path: php://stderr

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -51,12 +51,10 @@ when@prod:
             main_stdout:
                 type: stream
                 path: php://stdout
-                formatter: monolog.formatter.json
             errors_stderr:
                 type: stream
                 path: php://stderr
                 level: error
-                formatter: monolog.formatter.json
             mailer:
                 type: rotating_file
                 path: "%kernel.logs_dir%/mailer.log"
@@ -69,4 +67,3 @@ when@prod:
                 type: stream
                 channels: [deprecation]
                 path: php://stderr
-                formatter: monolog.formatter.json

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -4,9 +4,6 @@ monolog:
 
 when@dev:
     monolog:
-        channels:
-            - mailer
-
         handlers:
             # Journal principal de dev dans un fichier rotatif.
             main:
@@ -19,12 +16,6 @@ when@dev:
                 type: console
                 process_psr_3_messages: false
                 channels: ["!event", "!doctrine", "!console"]
-
-            # Journal dedié aux messages du canal mailer en dev.
-            mailer:
-                type: rotating_file
-                path: "%kernel.logs_dir%/mailer.log"
-                channels: mailer
 
 when@test:
     monolog:
@@ -46,7 +37,6 @@ when@prod:
     monolog:
         channels:
             - deprecation
-            - mailer
 
         handlers:
             # Filtre les niveaux notice à warning vers stdout (hors canaux dédiés).
@@ -55,32 +45,26 @@ when@prod:
                 handler: stdout_stream
                 min_level: notice
                 max_level: warning
-                channels: ["!deprecation", "!mailer"]
+                channels: ["!deprecation"]
 
             # Écrit les logs opérationnels sur stdout pour Kubernetes.
             stdout_stream:
                 type: stream
                 path: php://stdout
-                channels: ["!deprecation", "!mailer"]
+                channels: ["!deprecation"]
 
             # Écrit les erreurs et niveaux supérieurs sur stderr.
             stderr_error_plus:
                 type: stream
                 path: php://stderr
                 level: error
-                channels: ["!deprecation", "!mailer"]
+                channels: ["!deprecation"]
 
             # Isole les deprécations sur stderr via leur canal dédié.
             deprecation:
                 type: stream
                 path: php://stderr
                 channels: [deprecation]
-
-            # Conserve les logs mailer dans un fichier rotatif specifique.
-            mailer:
-                type: rotating_file
-                path: "%kernel.logs_dir%/mailer.log"
-                channels: [mailer]
 
             # Gère l'affichage des logs pour les commandes console en prod.
             console:

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -26,4 +26,14 @@ class AppController extends AbstractController
             'app_root' => $appRoot,
         ]);
     }
+
+    #[Route(
+        '/tableau-de-bord/health',
+        name: 'cartesgouvfr_app_health',
+        options: ['expose' => true]
+    )]
+    public function health(): Response
+    {
+        return new Response('OK', Response::HTTP_OK);
+    }
 }

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -25,7 +25,7 @@ class ContactController extends AbstractController
     public function __construct(
         private UserApiService $userApiService,
         private MailerService $mailerService,
-        private LoggerInterface $mailerLogger,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -79,9 +79,9 @@ class ContactController extends AbstractController
                 $supportMailParams['userId'] = $userApi['_id'];
             }
 
-            $this->mailerLogger->info('User ({userEmail}) : {message}', [
-                'userEmail' => $userEmail,
-                'message' => $message,
+            $this->logger->info('contact.request', [
+                'endpoint' => 'contact_us',
+                'is_authenticated' => $user instanceof User,
             ]);
 
             // envoi du mail à l'adresse du support
@@ -142,8 +142,9 @@ class ContactController extends AbstractController
 
             $userEmail = $user->getEmail();
 
-            $this->mailerLogger->info("User ({userEmail}) : Demande de création d'un entrepôt", [
-                'userEmail' => $userEmail,
+            $this->logger->info('datastore.creation.request', [
+                'endpoint' => 'datastore_create_request',
+                'is_authenticated' => $user instanceof User,
             ]);
 
             // Envoi du mail à l'adresse du support
@@ -190,10 +191,9 @@ class ContactController extends AbstractController
                 $mailParams['other_info'] = $data['other_info'];
             }
 
-            $this->mailerLogger->info(sprintf('User (%s) : Demande pour rejoindre %s', $userEmail, $data['community']['name']), [
-                'userEmail' => $userEmail,
-                'community' => $data['community'],
-                'other_info' => $data['other_info'] ?? null,
+            $this->logger->info('community.join.request', [
+                'endpoint' => 'join_community',
+                'is_authenticated' => $user instanceof User,
             ]);
 
             // Envoi du mail à l'adresse de contact de la communauté
@@ -254,8 +254,11 @@ class ContactController extends AbstractController
                 $mailParams['message'] = $data['message'];
             }
 
-            $context = array_merge(['userEmail' => $userEmail], $mailParams);
-            $this->mailerLogger->info('User ({userEmail}) : Demande d\'accès à des services de diffusion de données dont l\'accès est restreint', $context);
+            $this->logger->info('access.restricted.request', [
+                'endpoint' => 'accesses_request',
+                'is_authenticated' => $user instanceof User,
+                'layer_count' => count($data['layers'] ?? []),
+            ]);
 
             // Envoi du mail à l'adresse de contact des données
             $this->mailerService->sendMail(
@@ -306,8 +309,9 @@ class ContactController extends AbstractController
                 'community_id' => $datastore['community']['_id'],
             ];
 
-            $this->mailerLogger->info(sprintf("User (%s) : Demande de suppression de l'entrepôt %s", $userEmail, $datastore['name']), [
-                'userEmail' => $userEmail,
+            $this->logger->info('datastore.deletion.request', [
+                'endpoint' => 'datastore_deletion_request',
+                'is_authenticated' => $user instanceof User,
             ]);
 
             // Envoi du mail à l'adresse du support

--- a/src/Services/MailerService.php
+++ b/src/Services/MailerService.php
@@ -40,10 +40,16 @@ class MailerService
         try {
             $this->mailer->send($email);
         } catch (TransportExceptionInterface $ex) {
-            $this->logger->error('Sending mail failed, email address: {email_address}, email subject: {subject}', [
-                'subject' => $subject,
-                'email_address' => $to,
-                'debug' => $ex->getDebug(),
+            // On conserve uniquement le domaine pour diagnostiquer des incidents par fournisseur,
+            // sans exposer l'adresse email complète du destinataire.
+            $recipientDomain = substr(strrchr($to, '@') ?: '', 1) ?: 'unknown';
+
+            // Le hash du sujet permet de corréler des échecs similaires sans stocker le sujet en clair.
+            $this->logger->error('mail.transport.failure', [
+                'template' => $templateName,
+                'subject_hash' => hash('sha256', $subject),
+                'recipient_domain' => $recipientDomain,
+                'error_code' => $ex->getCode(),
             ]);
             throw $ex;
         }


### PR DESCRIPTION
Revue de la configuration des logs (mise à jour)
Cette PR simplifie les logs pour Kubernetes et réduit le bruit, avec un focus supplémentaire sur la confidentialité des logs applicatifs.

Apache :
- Filtrage des probes (healthcheck + internal dummy connection)
- Format de logs en texte simple
- Suppression des logs d’accès redondants

PHP :
- Erreurs non affichées à l’écran
- Redirection vers stderr

Symfony/Monolog :
- Flux séparés entre stdout (opérationnel) et stderr (erreurs)
- Suppression des formatters JSON/logstash
- Suppression du canal mailer dédié et du fichier rotatif associé

Logs métier mail (ajout) :
- Messages normalisés en événements machine-readable
- Logs assainis (pas de contenu libre ni d’email complet)
- En erreur transport, conservation de métadonnées techniques non sensibles

Healthcheck :
- Route dédiée /tableau-de-bord/health pour exclure les probes des access logs

Dépendances :
- Mise à jour de symfony/monolog-bundle et monolog/monolog

Objectif: des logs plus lisibles, moins bruyants, plus exploitables en prod, et mieux alignés avec la minimisation des données.

Actuellement déployé en dev.