### PR TITLE
fix(articles-scraper): encoder les URL S3 pour corriger le srcset cassé

### DIFF
--- a/bin/articles-scraper.mjs
+++ b/bin/articles-scraper.mjs
@@ -193,24 +193,28 @@ const downloadAllImages = async (document) => {
     await withConcurrency(imgList, async (img) => {
         // src
         const newSrc = await downloadFile(img.src);
-        img.src = ARTICLES_S3_GATEWAY_PATH_ARTICLES + newSrc.replace(OUTPUT_DIR, "");
+        img.src = toGatewayUrl(newSrc);
 
         // srcset
         if (img.srcset && img.srcset.length > 0) {
+            // Chaque candidate srcset est de la forme "<url> <descriptor>" (ex. "/img.png 325w").
+            // On split d'abord sur ", " pour séparer les candidates, puis on trim et on split sur
+            // les espaces/retours à la ligne pour séparer l'URL du descriptor.
+            // L'URL est ensuite encodée via toGatewayUrl() pour éviter que les espaces dans les
+            // noms de fichiers cassent le parsing du srcset côté navigateur.
             const srcSet = img.srcset.split(", ");
 
             const newSrcSet = await withConcurrency(srcSet, async (src) => {
                 // split pour séparer l'URL et le descriptor, voir : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset
-                const [originalImgPath, descriptor] = src.split(" ");
+                const [originalImgPath, descriptor] = src.trim().split(/\s+/);
 
                 const newSrc = await downloadFile(originalImgPath);
 
                 // reconstitution de l'URL
-                return ARTICLES_S3_GATEWAY_PATH_ARTICLES + newSrc.replace(OUTPUT_DIR, "") + (descriptor !== null ? " " + descriptor : "");
+                return toGatewayUrl(newSrc) + (descriptor ? " " + descriptor : "");
             });
 
-            const newSrcSetString = newSrcSet.join(", ");
-            img.srcset = newSrcSetString;
+            img.srcset = newSrcSet.join(", ");
         }
     });
 };
@@ -225,11 +229,23 @@ const downloadAllDownloadableFiles = async (document) => {
     await withConcurrency(downloadLinks, async (downLink) => {
         try {
             const newUrl = await downloadFile(downLink.href);
-            downLink.href = ARTICLES_S3_GATEWAY_PATH_ARTICLES + newUrl.replace(OUTPUT_DIR, "");
+            downLink.href = toGatewayUrl(newUrl);
         } catch (_) {
             downLink.removeAttribute("href");
         }
     });
+};
+
+/**
+ * Convertit un chemin de fichier local téléchargé en URL passerelle S3 correctement encodée.
+ * Indispensable car downloadFile() dé-encode les chemins (decodeURI) : sans ré-encodage,
+ * les espaces et virgules dans les noms de fichiers cassent le parsing du srcset.
+ * @param {string} localFilePath
+ */
+const toGatewayUrl = (localFilePath) => {
+    const relativePath = localFilePath.replace(OUTPUT_DIR, "");
+    const encoded = relativePath.split("/").map(encodeURIComponent).join("/");
+    return ARTICLES_S3_GATEWAY_PATH_ARTICLES + encoded;
 };
 
 /**


### PR DESCRIPTION
## Problème

Sur les pages d'actualités, les images responsive s'affichaient toujours à **325 px** même dans un conteneur de 1200 px, car le navigateur ignorait le `srcset` et retombait sur le `src` (la plus petite variante).

**Cause racine** : `downloadFile()` fait `decodeURI(newFilePath)` pour construire le chemin local (nécessaire pour écrire le fichier). Ce chemin dé-encodé était ensuite réinjecté tel quel dans les attributs `src` et `srcset`, sans ré-encodage. Les noms de fichiers contenant des espaces (ex. `img-Panoramax 1.png`) produisaient donc des URL invalides dans le `srcset` :

```
srcset="…/img-Panoramax 1.png 325w, …"
```

En syntaxe `srcset`, l'espace est le délimiteur URL/descriptor — les candidates étaient donc mal découpées et rejetées par le navigateur.

Vérifié empiriquement via Playwright : `renderedWidth: 1200`, `naturalWidth: 325`, `currentSrc → max_325x325` pour chaque image.

## Solution

- **`toGatewayUrl()`** : nouveau helper qui encode chaque segment du chemin via `encodeURIComponent` (espaces → `%20`, caractères accentués encodés, `/` préservés).
- **`downloadAllImages`** : `src` et `srcset` utilisent `toGatewayUrl()` au lieu de la concaténation manuelle ; parsing du `srcset` robustifié avec `.trim().split(/\s+/)` (gère aussi les retours à la ligne introduits par Prettier) ; garde du descriptor corrigée (`descriptor !== null` → `descriptor ?`, qui ajoutait `" undefined"` sur les candidates sans descriptor).
- **`downloadAllDownloadableFiles`** : même correction pour les `href` de documents téléchargeables (PDF, etc.).

## Test

Un re-scrape complet via le cron est nécessaire pour régénérer le HTML sur S3 avec les URL corrigées. Après re-scrape, vérifier via Playwright (viewport ≥ 1290 px) que `currentSrc → max_1300x1300` et `naturalWidth: 1300`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)