### PR TITLE
ci: fixe la catégorie SARIF Trivy pour éviter les doublons d'alertes

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -98,6 +98,8 @@ jobs:
               continue-on-error: true
               with:
                   sarif_file: "trivy-results.sarif"
+                  # Catégorie stable pour éviter les doublons d'alertes lors d'un renommage du job
+                  category: image-scan-trivy
 
             # Résumé sur la page du run (complète le résumé de build auto de build-push-action v6)
             - name: Write run summary


### PR DESCRIPTION
Ajoute une `category` explicite et stable (`image-scan-trivy`) à l'étape `upload-sarif`.

Sans elle, la catégorie était dérivée de `<fichier-workflow>:<job>` : le renommage du job dans #1094 a donc dupliqué les alertes Code Scanning (mêmes CVE sous plusieurs catégories, jamais refermées).

Nettoyage des alertes périmées à faire après merge, une fois les nouvelles alertes générées sous cette catégorie.