### PR TITLE
chore(deps): react-dsfr 1.17 -> 1.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "prettier": "^3.0.0"
             },
             "devDependencies": {
-                "@codegouvfr/react-dsfr": "^1.17.0",
+                "@codegouvfr/react-dsfr": "^1.32.4",
                 "@emotion/react": "^11.13.0",
                 "@emotion/styled": "^11.11.0",
                 "@eslint/js": "^9.37.0",
@@ -572,9 +572,9 @@
             "license": "(Apache-2.0 AND BSD-3-Clause)"
         },
         "node_modules/@codegouvfr/react-dsfr": {
-            "version": "1.32.2",
-            "resolved": "https://registry.npmjs.org/@codegouvfr/react-dsfr/-/react-dsfr-1.32.2.tgz",
-            "integrity": "sha512-x/NkMTJ1ULdvwSv79b1yA7NMxpcB4uaPrO2OfOZmfVH7psIap4AL2ctRPLgjw38BeLn9t2bcyjVrOPInyda9kw==",
+            "version": "1.32.4",
+            "resolved": "https://registry.npmjs.org/@codegouvfr/react-dsfr/-/react-dsfr-1.32.4.tgz",
+            "integrity": "sha512-yhjPqPObB3BsehZTRhJZ9qXwBRT2RZl0cn6hG838MlkPntTE5H5w0vU05KmKcdDBnQ0wDV59G7nnZrpKZQlNuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "prettier": "^3.0.0"
     },
     "devDependencies": {
-        "@codegouvfr/react-dsfr": "^1.17.0",
+        "@codegouvfr/react-dsfr": "^1.32.4",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.11.0",
         "@eslint/js": "^9.37.0",


### PR DESCRIPTION
## Quoi

Bump `@codegouvfr/react-dsfr` `^1.17.0` → `^1.32.4` (15 versions mineures de retard).

Préalable au spike TanStack Router : l'intégration `Link` (module augmentation) doit être validée contre la version réellement utilisée.

## Tests

- `update-icons`, `type-check`, `lint`, `build` OK sans aucune adaptation de code
- ⚠️ **Passe visuelle recommandée** avant merge (composants Header/Nav/Card/Tile notamment)