### PR TITLE
refactor: suppr de is_sandbox côté backend et dérivation côté frontend #1135

### DIFF
--- a/assets/@types/app.ts
+++ b/assets/@types/app.ts
@@ -8,7 +8,6 @@ import {
     BoundingBox,
     CheckingExecutionStandardDetailResponseDto,
     CheckingExecutionStandardDetailResponseDtoStatusEnum,
-    CommunityDetailResponseDto,
     CommunityMemberDto,
     CommunityUserResponseDtoRightsEnum,
     ConfigurationAltimetryDetailsContent,
@@ -60,13 +59,7 @@ export type CartesUser = {
 };
 
 /** datastore */
-export type Datastore = DatastoreDetailResponseDto & {
-    is_sandbox?: boolean;
-};
-
-export type Community = CommunityDetailResponseDto & {
-    is_sandbox?: boolean;
-};
+export type Datastore = DatastoreDetailResponseDto;
 
 /** fiche de donnée */
 export type Datasheet = {

--- a/assets/entrepot/components/DatastoreSideMenu.tsx
+++ b/assets/entrepot/components/DatastoreSideMenu.tsx
@@ -61,7 +61,7 @@ export default function DatastoreSideMenu({ datastoreId, communityId }: Datastor
                     isActive: !!matchRoute({ to: "/tableau-de-bord/entrepots" }),
                 },
                 ...datastoreList.map((datastore) => ({
-                    text: datastore.is_sandbox === true ? tCommon("sandbox") : datastore.name,
+                    text: tCommon("datastore_name", { name: datastore.name, isSandbox: datastore.is_sandbox }),
                     linkProps:
                         datastore._id !== undefined
                             ? { to: "/tableau-de-bord/entrepots/$datastoreId/donnees" as const, params: { datastoreId: datastore._id } }

--- a/assets/entrepot/hooks/queries/datasheetListQueryOptions.ts
+++ b/assets/entrepot/hooks/queries/datasheetListQueryOptions.ts
@@ -6,10 +6,7 @@ import RQKeys from "@/entrepot/modules/RQKeys";
 import { CartesApiException } from "@/modules/jsonFetch";
 import { delta } from "@/utils/delta";
 
-/**
- * Options communes de la requête liste des fiches de données (requête principale de la page).
- * throwOnError : toute erreur (dont 404 miroir) remonte à l'errorComponent du layout datastore.
- */
+/** throwOnError : toute erreur (dont 404 miroir) remonte à l'errorComponent du layout datastore */
 export function datasheetListQueryOptions(datastoreId: string): UseQueryOptions<Datasheet[], CartesApiException> {
     return {
         queryKey: RQKeys.datastore_datasheet_list(datastoreId),

--- a/assets/entrepot/hooks/useBreadcrumb.ts
+++ b/assets/entrepot/hooks/useBreadcrumb.ts
@@ -24,7 +24,6 @@ export default function useBreadcrumb(customBreadcrumbProps?: BreadcrumbProps) {
     const datastoreId = pathParams?.datastoreId ?? community?.datastore?._id;
     const { data: datastore } = useQuery<Datastore, CartesApiException>(datastoreQueryOptions(datastoreId));
 
-    // flags sandbox dérivés de l'appartenance (user_me) + env : le DTO ne porte plus is_sandbox
     const datastoreIsSandbox = isSandboxCommunity(findMembership(user, { datastoreId })?.community, sandboxCommunityId);
     const communityIsSandbox = isSandboxCommunity(community ?? undefined, sandboxCommunityId);
 

--- a/assets/entrepot/hooks/useBreadcrumb.ts
+++ b/assets/entrepot/hooks/useBreadcrumb.ts
@@ -5,7 +5,10 @@ import { use, useMemo } from "react";
 
 import { Datastore } from "@/@types/app";
 import { CommunityContext } from "@/entrepot/contexts/community";
+import { sandboxCommunityId } from "@/env";
+import useUserQuery from "@/hooks/queries/useUserQuery";
 import { CartesApiException } from "@/modules/jsonFetch";
+import { findMembership, isSandboxCommunity } from "@/utils";
 import { datastoreQueryOptions } from "./queries/datastoreQueryOptions";
 import getBreadcrumb, { BreadcrumbRouteParams } from "@/entrepot/modules/breadcrumbs/Breadcrumb";
 
@@ -15,10 +18,15 @@ export default function useBreadcrumb(customBreadcrumbProps?: BreadcrumbProps) {
     const pathParams = useParams({ strict: false, shouldThrow: false });
     const search: Record<string, unknown> | undefined = useSearch({ strict: false, shouldThrow: false });
     const community = use(CommunityContext);
+    const { data: user } = useUserQuery();
 
     // datastore courant : celui de l'URL, sinon celui de la communauté (lecture du cache, préchargé par les loaders)
     const datastoreId = pathParams?.datastoreId ?? community?.datastore?._id;
     const { data: datastore } = useQuery<Datastore, CartesApiException>(datastoreQueryOptions(datastoreId));
+
+    // flags sandbox dérivés de l'appartenance (user_me) + env : le DTO ne porte plus is_sandbox
+    const datastoreIsSandbox = isSandboxCommunity(findMembership(user, { datastoreId })?.community, sandboxCommunityId);
+    const communityIsSandbox = isSandboxCommunity(community ?? undefined, sandboxCommunityId);
 
     // id de la route matchée la plus profonde
     const routeId = matches[matches.length - 1]?.routeId;
@@ -39,6 +47,6 @@ export default function useBreadcrumb(customBreadcrumbProps?: BreadcrumbProps) {
             return customBreadcrumbProps;
         }
 
-        return getBreadcrumb(routeId, params, datastore, community);
-    }, [routeId, params, datastore, community, customBreadcrumbProps]);
+        return getBreadcrumb(routeId, params, datastore, community, { datastoreIsSandbox, communityIsSandbox });
+    }, [routeId, params, datastore, community, datastoreIsSandbox, communityIsSandbox, customBreadcrumbProps]);
 }

--- a/assets/entrepot/hooks/useMembership.ts
+++ b/assets/entrepot/hooks/useMembership.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 
 import { CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
+import { sandboxCommunityId } from "@/env";
 import useUserQuery from "@/hooks/queries/useUserQuery";
-import { CommunityRef, findMembership, hasRights, isSupervisor } from "@/utils";
+import { CommunityRef, findMembership, hasRights, isSandboxCommunity, isSupervisor } from "@/utils";
 
 /**
  * Appartenance de l'utilisateur courant à une communauté (par datastore ou par communauté),
@@ -22,6 +23,8 @@ export default function useMembership(ref: CommunityRef) {
         return {
             userId: user.id,
             membership,
+            community: membership.community,
+            isSandbox: isSandboxCommunity(membership.community, sandboxCommunityId),
             rights: membership.rights ?? [],
             isSupervisor: isSupervisor(user.id, membership),
             /** true si superviseur OU si l'utilisateur a TOUS les droits demandés */

--- a/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
+++ b/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
@@ -2,10 +2,10 @@ import { BreadcrumbProps, addBreadcrumbTranslations } from "@codegouvfr/react-ds
 
 import { Datastore } from "@/@types/app";
 import { CommunityDetailResponseDto } from "@/@types/entrepot";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { getTranslation } from "@/i18n/i18n";
 
 const { t } = getTranslation("Breadcrumb");
+const { t: tCommon } = getTranslation("Common");
 
 // Nom historique de la route (= clé i18n du fil d'Ariane), dérivé de l'id de route TanStack
 const breadcrumbNameByRouteId = {
@@ -101,11 +101,11 @@ const getBreadcrumb = (
             ...publishProps.segments,
             { label: t("datastore_selection"), linkProps: { to: "/tableau-de-bord/entrepots" } },
             datastoreId !== undefined && {
-                label: datastoreLabel(datastore?.name, datastoreIsSandbox),
+                label: tCommon("datastore_name", { name: datastore?.name, isSandbox: datastoreIsSandbox }),
                 linkProps: { to: "/tableau-de-bord/entrepots/$datastoreId/donnees", params: { datastoreId } },
             },
         ].filter(Boolean) as BreadcrumbProps["segments"],
-        currentPageLabel: datastoreLabel(datastore?.name, datastoreIsSandbox) || "",
+        currentPageLabel: tCommon("datastore_name", { name: datastore?.name, isSandbox: datastoreIsSandbox }) || "",
     };
 
     const espacecoBaseProps: BreadcrumbProps = {
@@ -145,7 +145,7 @@ const getBreadcrumb = (
                     params.communityId !== undefined &&
                         community !== undefined &&
                         datastore !== undefined && {
-                            label: datastoreLabel(community?.name, communityIsSandbox),
+                            label: tCommon("datastore_name", { name: community?.name, isSandbox: communityIsSandbox }),
                             linkProps: { to: "/tableau-de-bord/entrepots/$datastoreId/donnees", params: { datastoreId: datastore._id } },
                         },
                 ].filter(Boolean) as BreadcrumbProps["segments"],
@@ -177,7 +177,7 @@ const getBreadcrumb = (
             return {
                 ...publishProps,
                 segments: [...publishProps.segments, { label: t("datastore_selection"), linkProps: { to: "/tableau-de-bord/entrepots" } }],
-                currentPageLabel: datastoreLabel(datastore?.name, datastoreIsSandbox),
+                currentPageLabel: tCommon("datastore_name", { name: datastore?.name, isSandbox: datastoreIsSandbox }),
             };
 
         case "datastore_datasheet_upload": {

--- a/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
+++ b/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
@@ -1,10 +1,10 @@
 import { BreadcrumbProps, addBreadcrumbTranslations } from "@codegouvfr/react-dsfr/Breadcrumb";
 
 import { Community, Datastore } from "@/@types/app";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { getTranslation } from "@/i18n/i18n";
 
 const { t } = getTranslation("Breadcrumb");
-const { t: tCommon } = getTranslation("Common");
 
 // Nom historique de la route (= clé i18n du fil d'Ariane), dérivé de l'id de route TanStack
 const breadcrumbNameByRouteId = {
@@ -61,11 +61,18 @@ export type BreadcrumbRouteParams = {
     offeringId?: string;
 };
 
+/** Flags sandbox dérivés côté hook (membership + env) : le module pur ne peut pas les calculer lui-même */
+export type BreadcrumbSandboxFlags = {
+    datastoreIsSandbox: boolean;
+    communityIsSandbox: boolean;
+};
+
 const getBreadcrumb = (
     routeId: string | undefined,
     params: BreadcrumbRouteParams,
-    datastore?: Datastore,
-    community?: Community | null
+    datastore: Datastore | undefined,
+    community: Community | null | undefined,
+    { datastoreIsSandbox, communityIsSandbox }: BreadcrumbSandboxFlags
 ): BreadcrumbProps | undefined => {
     addBreadcrumbTranslations({
         lang: "fr",
@@ -93,11 +100,11 @@ const getBreadcrumb = (
             ...publishProps.segments,
             { label: t("datastore_selection"), linkProps: { to: "/tableau-de-bord/entrepots" } },
             datastoreId !== undefined && {
-                label: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name,
+                label: datastoreLabel(datastore?.name, datastoreIsSandbox),
                 linkProps: { to: "/tableau-de-bord/entrepots/$datastoreId/donnees", params: { datastoreId } },
             },
         ].filter(Boolean) as BreadcrumbProps["segments"],
-        currentPageLabel: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name || "",
+        currentPageLabel: datastoreLabel(datastore?.name, datastoreIsSandbox) || "",
     };
 
     const espacecoBaseProps: BreadcrumbProps = {
@@ -137,7 +144,7 @@ const getBreadcrumb = (
                     params.communityId !== undefined &&
                         community !== undefined &&
                         datastore !== undefined && {
-                            label: community?.is_sandbox === true ? tCommon("sandbox") : community?.name,
+                            label: datastoreLabel(community?.name, communityIsSandbox),
                             linkProps: { to: "/tableau-de-bord/entrepots/$datastoreId/donnees", params: { datastoreId: datastore._id } },
                         },
                 ].filter(Boolean) as BreadcrumbProps["segments"],
@@ -169,7 +176,7 @@ const getBreadcrumb = (
             return {
                 ...publishProps,
                 segments: [...publishProps.segments, { label: t("datastore_selection"), linkProps: { to: "/tableau-de-bord/entrepots" } }],
-                currentPageLabel: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name,
+                currentPageLabel: datastoreLabel(datastore?.name, datastoreIsSandbox),
             };
 
         case "datastore_datasheet_upload": {

--- a/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
+++ b/assets/entrepot/modules/breadcrumbs/Breadcrumb.ts
@@ -1,6 +1,7 @@
 import { BreadcrumbProps, addBreadcrumbTranslations } from "@codegouvfr/react-dsfr/Breadcrumb";
 
-import { Community, Datastore } from "@/@types/app";
+import { Datastore } from "@/@types/app";
+import { CommunityDetailResponseDto } from "@/@types/entrepot";
 import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { getTranslation } from "@/i18n/i18n";
 
@@ -71,7 +72,7 @@ const getBreadcrumb = (
     routeId: string | undefined,
     params: BreadcrumbRouteParams,
     datastore: Datastore | undefined,
-    community: Community | null | undefined,
+    community: CommunityDetailResponseDto | null | undefined,
     { datastoreIsSandbox, communityIsSandbox }: BreadcrumbSandboxFlags
 ): BreadcrumbProps | undefined => {
     addBreadcrumbTranslations({

--- a/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
+++ b/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
@@ -22,9 +22,12 @@ import PageTitle from "@/components/Layout/PageTitle";
 import LoadingOverlay from "@/components/Utils/LoadingOverlay";
 import { useCommunity } from "@/entrepot/contexts/community";
 import api from "@/entrepot/api";
+import { sandboxCommunityId } from "@/env";
 import { datastoreQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import useUserQuery from "@/hooks/queries/useUserQuery";
 import useMembership from "@/entrepot/hooks/useMembership";
+import { isSandboxCommunity } from "@/utils";
 import { getTranslation, useTranslation } from "@/i18n";
 import RQKeys from "@/entrepot/modules/RQKeys";
 import { CartesApiException } from "@/modules/jsonFetch";
@@ -73,6 +76,7 @@ export default function CommunityInfo() {
     const userQuery = useUserQuery();
     const { data: user } = userQuery;
     const community: Community = useCommunity();
+    const isSandbox = isSandboxCommunity(community, sandboxCommunityId);
     const { data: datastore } = useQuery<Datastore, CartesApiException>(datastoreQueryOptions(community.datastore?._id)); // communauté possiblement sans entrepôt
 
     const queryClient = useQueryClient();
@@ -146,11 +150,8 @@ export default function CommunityInfo() {
     });
 
     return (
-        <DatastoreMain
-            title={t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : (datastore?.name ?? community.name) })}
-            datastoreId={datastore?._id}
-        >
-            <PageTitle title={t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : (datastore?.name ?? community.name) })} />
+        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name ?? community.name, isSandbox) })} datastoreId={datastore?._id}>
+            <PageTitle title={t("title", { datastoreName: datastoreLabel(datastore?.name ?? community.name, isSandbox) })} />
 
             {datastore && <DatastoreTertiaryNavigation datastoreId={datastore._id} communityId={community._id} />}
 
@@ -267,7 +268,7 @@ export default function CommunityInfo() {
                         },
                     ]}
                 >
-                    {t("leave_modal.body", { datastoreName: community.is_sandbox === true ? tCommon("sandbox") : community?.name })}
+                    {t("leave_modal.body", { datastoreName: datastoreLabel(community?.name, isSandbox) })}
                 </leaveCommunityModal.Component>,
                 document.body
             )}

--- a/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
+++ b/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
@@ -24,7 +24,6 @@ import { useCommunity } from "@/entrepot/contexts/community";
 import api from "@/entrepot/api";
 import { sandboxCommunityId } from "@/env";
 import { datastoreQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import useUserQuery from "@/hooks/queries/useUserQuery";
 import useMembership from "@/entrepot/hooks/useMembership";
 import { isSandboxCommunity } from "@/utils";
@@ -150,8 +149,11 @@ export default function CommunityInfo() {
     });
 
     return (
-        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name ?? community.name, isSandbox) })} datastoreId={datastore?._id}>
-            <PageTitle title={t("title", { datastoreName: datastoreLabel(datastore?.name ?? community.name, isSandbox) })} />
+        <DatastoreMain
+            title={t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name ?? community.name, isSandbox }) })}
+            datastoreId={datastore?._id}
+        >
+            <PageTitle title={t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name ?? community.name, isSandbox }) })} />
 
             {datastore && <DatastoreTertiaryNavigation datastoreId={datastore._id} communityId={community._id} />}
 
@@ -268,7 +270,7 @@ export default function CommunityInfo() {
                         },
                     ]}
                 >
-                    {t("leave_modal.body", { datastoreName: datastoreLabel(community?.name, isSandbox) })}
+                    {t("leave_modal.body", { datastoreName: tCommon("datastore_name", { name: community?.name, isSandbox }) })}
                 </leaveCommunityModal.Component>,
                 document.body
             )}

--- a/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
+++ b/assets/entrepot/pages/communities/CommunityInfo/CommunityInfo.tsx
@@ -14,7 +14,7 @@ import { useStyles } from "tss-react";
 import isEmail from "validator/lib/isEmail";
 import * as yup from "yup";
 
-import { Community, Datastore } from "@/@types/app";
+import { Datastore } from "@/@types/app";
 import { CommunityDetailResponseDto, CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
 import DatastoreMain from "@/entrepot/components/DatastoreMain";
 import DatastoreTertiaryNavigation from "@/entrepot/components/DatastoreTertiaryNavigation";
@@ -75,7 +75,7 @@ export default function CommunityInfo() {
 
     const userQuery = useUserQuery();
     const { data: user } = userQuery;
-    const community: Community = useCommunity();
+    const community: CommunityDetailResponseDto = useCommunity();
     const isSandbox = isSandboxCommunity(community, sandboxCommunityId);
     const { data: datastore } = useQuery<Datastore, CartesApiException>(datastoreQueryOptions(community.datastore?._id)); // communauté possiblement sans entrepôt
 

--- a/assets/entrepot/pages/data_details/StoredDataDetails.tsx
+++ b/assets/entrepot/pages/data_details/StoredDataDetails.tsx
@@ -6,6 +6,8 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { FC, useEffect, useMemo, useState } from "react";
 
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { StoredDataReport, StoredDataStatusEnum } from "../../../@types/app";
 import LoadingIcon from "../../../components/Utils/LoadingIcon";
 import RQKeys from "@/entrepot/modules/RQKeys";
@@ -21,7 +23,10 @@ type StoredDataDetailsProps = {
 };
 const StoredDataDetails: FC<StoredDataDetailsProps> = ({ datastoreId, storedDataId }) => {
     const [reportQueryEnabled, setReportQueryEnabled] = useState(true);
-    const { data: datastore } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
+    useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const membership = useDatastoreMembership();
+    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox === true);
 
     const reportQuery = useQuery<StoredDataReport, CartesApiException>({
         queryKey: RQKeys.datastore_stored_data_report(datastoreId, storedDataId),
@@ -91,7 +96,7 @@ const StoredDataDetails: FC<StoredDataDetailsProps> = ({ datastoreId, storedData
                                 },
                                 {
                                     label: "Rapport de génération",
-                                    content: <ReportTab datastoreName={datastore?.name} reportQuery={reportQuery} />,
+                                    content: <ReportTab datastoreName={datastoreName} reportQuery={reportQuery} />,
                                 },
                             ]}
                         />

--- a/assets/entrepot/pages/data_details/StoredDataDetails.tsx
+++ b/assets/entrepot/pages/data_details/StoredDataDetails.tsx
@@ -7,7 +7,7 @@ import { FC, useEffect, useMemo, useState } from "react";
 
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
+import { useTranslation } from "@/i18n";
 import { StoredDataReport, StoredDataStatusEnum } from "../../../@types/app";
 import LoadingIcon from "../../../components/Utils/LoadingIcon";
 import RQKeys from "@/entrepot/modules/RQKeys";
@@ -23,10 +23,11 @@ type StoredDataDetailsProps = {
 };
 const StoredDataDetails: FC<StoredDataDetailsProps> = ({ datastoreId, storedDataId }) => {
     const [reportQueryEnabled, setReportQueryEnabled] = useState(true);
-    // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
+    // conserve le blocage et le miroir-404 de la page
     useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const { t: tCommon } = useTranslation("Common");
     const membership = useDatastoreMembership();
-    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox);
+    const datastoreName = tCommon("datastore_name", { name: membership?.community?.name, isSandbox: membership?.isSandbox });
 
     const reportQuery = useQuery<StoredDataReport, CartesApiException>({
         queryKey: RQKeys.datastore_stored_data_report(datastoreId, storedDataId),

--- a/assets/entrepot/pages/data_details/StoredDataDetails.tsx
+++ b/assets/entrepot/pages/data_details/StoredDataDetails.tsx
@@ -26,7 +26,7 @@ const StoredDataDetails: FC<StoredDataDetailsProps> = ({ datastoreId, storedData
     // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
     useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
     const membership = useDatastoreMembership();
-    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox === true);
+    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox);
 
     const reportQuery = useQuery<StoredDataReport, CartesApiException>({
         queryKey: RQKeys.datastore_stored_data_report(datastoreId, storedDataId),

--- a/assets/entrepot/pages/data_details/UploadDetails.tsx
+++ b/assets/entrepot/pages/data_details/UploadDetails.tsx
@@ -26,7 +26,7 @@ const UploadDetails: FC<UploadDetailsProps> = ({ datastoreId, uploadId }) => {
     // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
     useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
     const membership = useDatastoreMembership();
-    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox === true);
+    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox);
 
     const reportQuery = useQuery<UploadReport, CartesApiException>({
         queryKey: RQKeys.datastore_upload_report(datastoreId, uploadId),

--- a/assets/entrepot/pages/data_details/UploadDetails.tsx
+++ b/assets/entrepot/pages/data_details/UploadDetails.tsx
@@ -6,6 +6,8 @@ import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { FC, useMemo } from "react";
 
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { UploadReport } from "../../../@types/app";
 import LoadingIcon from "../../../components/Utils/LoadingIcon";
 import RQKeys from "@/entrepot/modules/RQKeys";
@@ -21,7 +23,10 @@ type UploadDetailsProps = {
 };
 
 const UploadDetails: FC<UploadDetailsProps> = ({ datastoreId, uploadId }) => {
-    const { data: datastore } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
+    useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const membership = useDatastoreMembership();
+    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox === true);
 
     const reportQuery = useQuery<UploadReport, CartesApiException>({
         queryKey: RQKeys.datastore_upload_report(datastoreId, uploadId),
@@ -80,7 +85,7 @@ const UploadDetails: FC<UploadDetailsProps> = ({ datastoreId, uploadId }) => {
                                 },
                                 {
                                     label: "Rapport de livraison",
-                                    content: <ReportTab datastoreName={datastore?.name} reportQuery={reportQuery} />,
+                                    content: <ReportTab datastoreName={datastoreName} reportQuery={reportQuery} />,
                                 },
                             ]}
                         />

--- a/assets/entrepot/pages/data_details/UploadDetails.tsx
+++ b/assets/entrepot/pages/data_details/UploadDetails.tsx
@@ -7,7 +7,7 @@ import { FC, useMemo } from "react";
 
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
+import { useTranslation } from "@/i18n";
 import { UploadReport } from "../../../@types/app";
 import LoadingIcon from "../../../components/Utils/LoadingIcon";
 import RQKeys from "@/entrepot/modules/RQKeys";
@@ -23,10 +23,11 @@ type UploadDetailsProps = {
 };
 
 const UploadDetails: FC<UploadDetailsProps> = ({ datastoreId, uploadId }) => {
-    // conserve le blocage et le miroir-404 de la page ; le nom d'affichage vient de l'appartenance
+    // conserve le blocage et le miroir-404 de la page
     useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const { t: tCommon } = useTranslation("Common");
     const membership = useDatastoreMembership();
-    const datastoreName = datastoreLabel(membership?.community?.name, membership?.isSandbox);
+    const datastoreName = tCommon("datastore_name", { name: membership?.community?.name, isSandbox: membership?.isSandbox });
 
     const reportQuery = useQuery<UploadReport, CartesApiException>({
         queryKey: RQKeys.datastore_upload_report(datastoreId, uploadId),

--- a/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
@@ -17,7 +17,7 @@ import { ListHeader } from "@/components/Layout/ListHeader";
 import PageTitle from "@/components/Layout/PageTitle";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import { datasheetListQueryOptions } from "@/entrepot/hooks/queries/datasheetListQueryOptions";
-import { sandboxCommunityId } from "@/env";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { FilterEnum, useFilters } from "@/hooks/useFilters";
 import { usePagination } from "@/hooks/usePagination";
 import { useSearch } from "@/hooks/useSearch";
@@ -49,9 +49,9 @@ const DatasheetList: FC<DatasheetListProps> = ({ datastoreId }) => {
 
     // titre, sandbox et navigation dérivés de l'appartenance (user_me, synchrone) : la requête datastore ne bloque plus la page
     const membership = useDatastoreMembership();
-    const community = membership?.membership.community;
-    const isSandbox = sandboxCommunityId !== null && community?._id === sandboxCommunityId;
-    const datastoreName = isSandbox ? tCommon("sandbox") : community?.name;
+    const community = membership?.community;
+    const isSandbox = membership?.isSandbox === true;
+    const datastoreName = datastoreLabel(community?.name, isSandbox);
 
     const datasheetListQuery = useQuery(datasheetListQueryOptions(datastoreId));
     const { data: datasheetList, dataUpdatedAt, isFetching, isLoading, refetch } = datasheetListQuery;

--- a/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
@@ -17,7 +17,6 @@ import { ListHeader } from "@/components/Layout/ListHeader";
 import PageTitle from "@/components/Layout/PageTitle";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import { datasheetListQueryOptions } from "@/entrepot/hooks/queries/datasheetListQueryOptions";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { FilterEnum, useFilters } from "@/hooks/useFilters";
 import { usePagination } from "@/hooks/usePagination";
 import { useSearch } from "@/hooks/useSearch";
@@ -47,11 +46,10 @@ const DatasheetList: FC<DatasheetListProps> = ({ datastoreId }) => {
     const { t } = useTranslation("DatasheetList");
     const { t: tCommon } = useTranslation("Common");
 
-    // titre, sandbox et navigation dérivés de l'appartenance (user_me, synchrone) : la requête datastore ne bloque plus la page
     const membership = useDatastoreMembership();
     const community = membership?.community;
     const isSandbox = membership?.isSandbox;
-    const datastoreName = datastoreLabel(community?.name, isSandbox);
+    const datastoreName = tCommon("datastore_name", { name: community?.name, isSandbox });
 
     const datasheetListQuery = useQuery(datasheetListQueryOptions(datastoreId));
     const { data: datasheetList, dataUpdatedAt, isFetching, isLoading, refetch } = datasheetListQuery;

--- a/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetList/DatasheetList.tsx
@@ -50,7 +50,7 @@ const DatasheetList: FC<DatasheetListProps> = ({ datastoreId }) => {
     // titre, sandbox et navigation dérivés de l'appartenance (user_me, synchrone) : la requête datastore ne bloque plus la page
     const membership = useDatastoreMembership();
     const community = membership?.community;
-    const isSandbox = membership?.isSandbox === true;
+    const isSandbox = membership?.isSandbox;
     const datastoreName = datastoreLabel(community?.name, isSandbox);
 
     const datasheetListQuery = useQuery(datasheetListQueryOptions(datastoreId));

--- a/assets/entrepot/pages/datasheet/DatasheetView/MetadataTab/MetadataTab.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/MetadataTab/MetadataTab.tsx
@@ -32,7 +32,7 @@ const MetadataTab: FC<MetadataTabProps> = ({ datastoreId, metadataQuery }) => {
     const { data: metadata } = metadataQuery;
 
     const datastoreQuery = useQuery(datastoreQueryOptions(datastoreId));
-    const isSandbox = useDatastoreMembership()?.isSandbox === true;
+    const isSandbox = useDatastoreMembership()?.isSandbox;
 
     const frequencyCode = useMemo(() => {
         const code = metadata?.csw_metadata?.frequency_code;

--- a/assets/entrepot/pages/datasheet/DatasheetView/MetadataTab/MetadataTab.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/MetadataTab/MetadataTab.tsx
@@ -7,15 +7,15 @@ import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { FC, useMemo } from "react";
 
 import { catalogueUrl } from "@/env";
+import { datastoreQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
 import { getThematicCategories } from "@/entrepot/utils/metadata";
 import { MetadataHierarchyLevel, type Metadata } from "../../../../../@types/app";
 import ExtentMap from "@/entrepot/components/ExtentMap";
 import LoadingText from "../../../../../components/Utils/LoadingText";
 import TextCopyToClipboard from "../../../../../components/Utils/TextCopyToClipboard";
 import { useTranslation } from "../../../../../i18n/i18n";
-import RQKeys from "@/entrepot/modules/RQKeys";
 import { CartesApiException } from "../../../../../modules/jsonFetch";
-import api from "../../../../api";
 import MetadataField from "./MetadataField";
 
 import frequencyCodes from "@/entrepot/data/maintenance_frequency.json";
@@ -31,11 +31,8 @@ const MetadataTab: FC<MetadataTabProps> = ({ datastoreId, metadataQuery }) => {
 
     const { data: metadata } = metadataQuery;
 
-    const datastoreQuery = useQuery({
-        queryKey: RQKeys.datastore(datastoreId),
-        queryFn: ({ signal }) => api.datastore.get(datastoreId, { signal }),
-        staleTime: 3600000,
-    });
+    const datastoreQuery = useQuery(datastoreQueryOptions(datastoreId));
+    const isSandbox = useDatastoreMembership()?.isSandbox === true;
 
     const frequencyCode = useMemo(() => {
         const code = metadata?.csw_metadata?.frequency_code;
@@ -44,7 +41,7 @@ const MetadataTab: FC<MetadataTabProps> = ({ datastoreId, metadataQuery }) => {
 
     const catalogueDatasheetUrl = useMemo(() => {
         // si datastore sandbox
-        if (datastoreQuery.data?.is_sandbox === true) {
+        if (isSandbox) {
             const metadataEndpoint = datastoreQuery.data?.endpoints?.find((ep) => ep.endpoint._id === metadata?.endpoints?.[0]?._id);
             const cswBaseUrl = metadataEndpoint?.endpoint.urls?.[0].url.trim();
 
@@ -55,7 +52,7 @@ const MetadataTab: FC<MetadataTabProps> = ({ datastoreId, metadataQuery }) => {
         }
 
         return `${catalogueUrl}/dataset/${metadata?.file_identifier}`;
-    }, [metadata?.file_identifier, datastoreQuery.data?.is_sandbox, datastoreQuery.data?.endpoints, metadata?.endpoints]);
+    }, [metadata?.file_identifier, isSandbox, datastoreQuery.data?.endpoints, metadata?.endpoints]);
 
     const isPublished = useMemo(
         () => metadataQuery.data?.endpoints?.length !== undefined && metadataQuery.data?.endpoints?.length > 0,
@@ -77,7 +74,7 @@ const MetadataTab: FC<MetadataTabProps> = ({ datastoreId, metadataQuery }) => {
                 <div className={fr.cx("fr-grid-row", "fr-grid-row--center", "fr-grid-row--middle")}>
                     <div className={fr.cx("fr-col-12")}>
                         {isPublished ? (
-                            datastoreQuery.data?.is_sandbox === true ? (
+                            isSandbox ? (
                                 <CallOut
                                     buttonProps={{
                                         children: "Consulter le service de métadonnées",

--- a/assets/entrepot/pages/datastore/DatastoreSelection/DatastoreSelection.tsx
+++ b/assets/entrepot/pages/datastore/DatastoreSelection/DatastoreSelection.tsx
@@ -49,7 +49,7 @@ export default function DatastoreSelection() {
                         <Card
                             imageUrl={datastore.is_sandbox === true ? sandboxDatastoreThumbnailSvg : placeholder16x9}
                             imageAlt=""
-                            title={datastore.is_sandbox === true ? tCommon("sandbox") : datastore.name}
+                            title={tCommon("datastore_name", { name: datastore.name, isSandbox: datastore.is_sandbox })}
                             titleAs="h6"
                             linkProps={
                                 datastore._id !== undefined

--- a/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
@@ -19,6 +19,8 @@ import { ListHeader } from "@/components/Layout/ListHeader";
 import PageTitle from "@/components/Layout/PageTitle";
 import Skeleton from "@/components/Utils/Skeleton";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { usePagination } from "@/hooks/usePagination";
 import { searchAwareActiveOptions } from "@/router/AppLink";
 import { formatDateFromISO } from "@/utils";
@@ -43,6 +45,7 @@ const DatastoreManagePermissions: FC<DatastoreManagePermissionsProps> = ({ datas
 
     // Le datastore (le chargement initial est couvert par la Suspense de la route)
     const { data: datastore } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const isSandbox = useDatastoreMembership()?.isSandbox === true;
 
     // Les permissions
     const {
@@ -82,8 +85,8 @@ const DatastoreManagePermissions: FC<DatastoreManagePermissionsProps> = ({ datas
     const { css } = useStyles();
 
     return (
-        <DatastoreMain title={t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name })} datastoreId={datastoreId}>
-            <PageTitle title={t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name })} />
+        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} datastoreId={datastoreId}>
+            <PageTitle title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} />
 
             <DatastoreTertiaryNavigation datastoreId={datastoreId} communityId={datastore.community._id} />
 

--- a/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
@@ -20,7 +20,6 @@ import PageTitle from "@/components/Layout/PageTitle";
 import Skeleton from "@/components/Utils/Skeleton";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import { usePagination } from "@/hooks/usePagination";
 import { searchAwareActiveOptions } from "@/router/AppLink";
 import { formatDateFromISO } from "@/utils";
@@ -85,8 +84,8 @@ const DatastoreManagePermissions: FC<DatastoreManagePermissionsProps> = ({ datas
     const { css } = useStyles();
 
     return (
-        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} datastoreId={datastoreId}>
-            <PageTitle title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} />
+        <DatastoreMain title={t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name, isSandbox }) })} datastoreId={datastoreId}>
+            <PageTitle title={t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name, isSandbox }) })} />
 
             <DatastoreTertiaryNavigation datastoreId={datastoreId} communityId={datastore.community._id} />
 

--- a/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/DatastoreManagePermissions.tsx
@@ -45,7 +45,7 @@ const DatastoreManagePermissions: FC<DatastoreManagePermissionsProps> = ({ datas
 
     // Le datastore (le chargement initial est couvert par la Suspense de la route)
     const { data: datastore } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
-    const isSandbox = useDatastoreMembership()?.isSandbox === true;
+    const isSandbox = useDatastoreMembership()?.isSandbox;
 
     // Les permissions
     const {

--- a/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
@@ -28,7 +28,7 @@ const DatastoreManageStorage: FC = () => {
     const { t } = useTranslation("DatastoreManageStorage");
     const { datastoreId } = route.useParams();
     const { data: datastore, isFetching } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
-    const isSandbox = useDatastoreMembership()?.isSandbox === true;
+    const isSandbox = useDatastoreMembership()?.isSandbox;
 
     const navigate = useNavigate();
     const { tab: currentTab } = route.useSearch();

--- a/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
@@ -9,7 +9,6 @@ import DatastoreTertiaryNavigation from "@/entrepot/components/DatastoreTertiary
 import PageTitle from "@/components/Layout/PageTitle";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
 import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
-import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import LoadingIcon from "../../../../components/Utils/LoadingIcon";
 import { useTranslation } from "../../../../i18n/i18n";
 import AnnexeUsage from "./storages/AnnexeUsage";
@@ -26,6 +25,7 @@ const route = getRouteApi("/_private/tableau-de-bord/entrepots/$datastoreId/cons
 
 const DatastoreManageStorage: FC = () => {
     const { t } = useTranslation("DatastoreManageStorage");
+    const { t: tCommon } = useTranslation("Common");
     const { datastoreId } = route.useParams();
     const { data: datastore, isFetching } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
     const isSandbox = useDatastoreMembership()?.isSandbox;
@@ -43,11 +43,11 @@ const DatastoreManageStorage: FC = () => {
     });
 
     return (
-        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} datastoreId={datastore._id}>
+        <DatastoreMain title={t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name, isSandbox }) })} datastoreId={datastore._id}>
             <PageTitle
                 title={
                     <>
-                        {t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })}
+                        {t("title", { datastoreName: tCommon("datastore_name", { name: datastore?.name, isSandbox }) })}
                         {isFetching && <LoadingIcon className={fr.cx("fr-ml-2w")} largeIcon />}
                     </>
                 }

--- a/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
+++ b/assets/entrepot/pages/datastore/ManageStorage/DatastoreManageStorage.tsx
@@ -8,6 +8,8 @@ import DatastoreMain from "@/entrepot/components/DatastoreMain";
 import DatastoreTertiaryNavigation from "@/entrepot/components/DatastoreTertiaryNavigation";
 import PageTitle from "@/components/Layout/PageTitle";
 import { datastoreSuspenseQueryOptions } from "@/entrepot/hooks/queries/datastoreQueryOptions";
+import useDatastoreMembership from "@/entrepot/hooks/useDatastoreMembership";
+import { datastoreLabel } from "@/entrepot/utils/datastoreLabel";
 import LoadingIcon from "../../../../components/Utils/LoadingIcon";
 import { useTranslation } from "../../../../i18n/i18n";
 import AnnexeUsage from "./storages/AnnexeUsage";
@@ -24,9 +26,9 @@ const route = getRouteApi("/_private/tableau-de-bord/entrepots/$datastoreId/cons
 
 const DatastoreManageStorage: FC = () => {
     const { t } = useTranslation("DatastoreManageStorage");
-    const { t: tCommon } = useTranslation("Common");
     const { datastoreId } = route.useParams();
     const { data: datastore, isFetching } = useSuspenseQuery(datastoreSuspenseQueryOptions(datastoreId));
+    const isSandbox = useDatastoreMembership()?.isSandbox === true;
 
     const navigate = useNavigate();
     const { tab: currentTab } = route.useSearch();
@@ -41,11 +43,11 @@ const DatastoreManageStorage: FC = () => {
     });
 
     return (
-        <DatastoreMain title={t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name })} datastoreId={datastore._id}>
+        <DatastoreMain title={t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })} datastoreId={datastore._id}>
             <PageTitle
                 title={
                     <>
-                        {t("title", { datastoreName: datastore?.is_sandbox === true ? tCommon("sandbox") : datastore?.name })}
+                        {t("title", { datastoreName: datastoreLabel(datastore?.name, isSandbox) })}
                         {isFetching && <LoadingIcon className={fr.cx("fr-ml-2w")} largeIcon />}
                     </>
                 }

--- a/assets/entrepot/utils/datastoreLabel.ts
+++ b/assets/entrepot/utils/datastoreLabel.ts
@@ -1,8 +1,0 @@
-import { getTranslation } from "@/i18n/i18n";
-
-const { t: tCommon } = getTranslation("Common");
-
-/** Nom d'affichage d'un entrepôt : libellé sandbox localisé, sinon le nom de la communauté (statut inconnu = pas sandbox) */
-export function datastoreLabel(name: string | undefined, isSandbox: boolean | undefined): string | undefined {
-    return isSandbox ? tCommon("sandbox") : name;
-}

--- a/assets/entrepot/utils/datastoreLabel.ts
+++ b/assets/entrepot/utils/datastoreLabel.ts
@@ -1,0 +1,8 @@
+import { getTranslation } from "@/i18n/i18n";
+
+const { t: tCommon } = getTranslation("Common");
+
+/** Nom d'affichage d'un entrepôt : libellé sandbox localisé, sinon le nom de la communauté */
+export function datastoreLabel(name: string | undefined, isSandbox: boolean): string | undefined {
+    return isSandbox ? tCommon("sandbox") : name;
+}

--- a/assets/entrepot/utils/datastoreLabel.ts
+++ b/assets/entrepot/utils/datastoreLabel.ts
@@ -2,7 +2,7 @@ import { getTranslation } from "@/i18n/i18n";
 
 const { t: tCommon } = getTranslation("Common");
 
-/** Nom d'affichage d'un entrepôt : libellé sandbox localisé, sinon le nom de la communauté */
-export function datastoreLabel(name: string | undefined, isSandbox: boolean): string | undefined {
+/** Nom d'affichage d'un entrepôt : libellé sandbox localisé, sinon le nom de la communauté (statut inconnu = pas sandbox) */
+export function datastoreLabel(name: string | undefined, isSandbox: boolean | undefined): string | undefined {
     return isSandbox ? tCommon("sandbox") : name;
 }

--- a/assets/i18n/Common.locale.tsx
+++ b/assets/i18n/Common.locale.tsx
@@ -54,7 +54,7 @@ const { i18n } = declareComponentKeys<
     | "select_option"
     | { K: "last_refresh_date"; P: { dataUpdatedAt: number }; R: string }
     | { K: "nb_results"; P: { displayed: number; total: number }; R: string }
-    | "sandbox"
+    | { K: "datastore_name"; P: { name: string | undefined; isSandbox: boolean | undefined }; R: string | undefined }
     | "email_notification"
 >()("Common");
 export type I18n = typeof i18n;
@@ -115,7 +115,7 @@ export const commonFrTranslations: Translations<"fr">["Common"] = {
         if (total === 1) return "1 résultat affiché sur 1";
         return `${displayed} résultats affichés sur ${total}`;
     },
-    sandbox: "Espace Découverte",
+    datastore_name: ({ name, isSandbox }) => (isSandbox ? "Espace Découverte" : name),
     email_notification: "Être notifié par courriel à la fin de la génération",
 };
 
@@ -171,6 +171,6 @@ export const commonEnTranslations: Translations<"en">["Common"] = {
     select_option: "Select an option",
     last_refresh_date: undefined,
     nb_results: undefined,
-    sandbox: undefined,
+    datastore_name: undefined,
     email_notification: undefined,
 };

--- a/assets/utils/membership.test.ts
+++ b/assets/utils/membership.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { CartesUser } from "@/@types/app";
 import { CommunityMemberDto, CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
-import { findMembership, hasAccess, hasRights, isSupervisor } from "./membership";
+import { findMembership, hasAccess, hasRights, isSandboxCommunity, isSupervisor } from "./membership";
 
 const USER_ID = "user-1";
 const SUPERVISOR_ID = "supervisor-1";
@@ -56,6 +56,18 @@ describe("findMembership", () => {
         }
         expect(findMembership(user([withoutCommunity, noDatastore]), { datastoreId: "datastore-1" })).toBeUndefined();
         expect(findMembership(user([withoutCommunity, noDatastore]), { communityId: "community-3" })).toBe(noDatastore);
+    });
+});
+
+describe("isSandboxCommunity", () => {
+    it("reconnaît la communauté bac à sable par son id", () => {
+        expect(isSandboxCommunity(communityMember().community, "community-1")).toBe(true);
+        expect(isSandboxCommunity(communityMember().community, "community-2")).toBe(false);
+    });
+
+    it("jamais sandbox sans id configuré ou sans communauté", () => {
+        expect(isSandboxCommunity(communityMember().community, null)).toBe(false);
+        expect(isSandboxCommunity(undefined, "community-1")).toBe(false);
     });
 });
 

--- a/assets/utils/membership.ts
+++ b/assets/utils/membership.ts
@@ -21,7 +21,7 @@ export function findMembership(user: CartesUser | null | undefined, criteria: { 
 }
 
 /** true si la communauté est celle du bac à sable (id absent de la config : jamais sandbox) */
-export function isSandboxCommunity(community: CommunityUserDto | undefined, sandboxCommunityId: string | null): boolean {
+export function isSandboxCommunity(community: Pick<CommunityUserDto, "_id"> | undefined, sandboxCommunityId: string | null): boolean {
     return sandboxCommunityId !== null && community?._id === sandboxCommunityId;
 }
 

--- a/assets/utils/membership.ts
+++ b/assets/utils/membership.ts
@@ -1,5 +1,5 @@
 import { CartesUser } from "@/@types/app";
-import { CommunityMemberDto, CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
+import { CommunityMemberDto, CommunityMemberDtoRightsEnum, CommunityUserDto } from "@/@types/entrepot";
 
 /** Désigne une communauté, directement ou via son datastore */
 export type CommunityRef = { datastoreId: string; communityId?: never } | { communityId: string; datastoreId?: never };
@@ -18,6 +18,11 @@ export function findMembership(user: CartesUser | null | undefined, criteria: { 
         if (datastoreId !== undefined) return member.community.datastore === datastoreId;
         return member.community._id === communityId;
     });
+}
+
+/** true si la communauté est celle du bac à sable (id absent de la config : jamais sandbox) */
+export function isSandboxCommunity(community: CommunityUserDto | undefined, sandboxCommunityId: string | null): boolean {
+    return sandboxCommunityId !== null && community?._id === sandboxCommunityId;
 }
 
 /** true si l'utilisateur est le superviseur de la communauté */

--- a/src/Controller/Entrepot/CommunityController.php
+++ b/src/Controller/Entrepot/CommunityController.php
@@ -8,7 +8,6 @@ use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\CommunityApiService;
 use App\Services\EntrepotApi\UserApiService;
-use App\Services\SandboxService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,7 +25,6 @@ class CommunityController extends AbstractController implements ApiControllerInt
 {
     public function __construct(
         private CommunityApiService $communityApiService,
-        private SandboxService $sandboxService,
         private UserApiService $userApiService,
     ) {
     }
@@ -36,7 +34,6 @@ class CommunityController extends AbstractController implements ApiControllerInt
     {
         try {
             $community = $this->communityApiService->get($communityId)->array();
-            $community['is_sandbox'] = $this->sandboxService->isSandboxCommunity($community['_id']);
 
             return new JsonResponse($community);
         } catch (ApiException $ex) {
@@ -50,7 +47,6 @@ class CommunityController extends AbstractController implements ApiControllerInt
         try {
             $data = json_decode($request->getContent(), true);
             $community = $this->communityApiService->modifyCommunity($communityId, $data)->array();
-            $community['is_sandbox'] = $this->sandboxService->isSandboxCommunity($community['_id']);
 
             return new JsonResponse($community);
         } catch (ApiException $ex) {

--- a/src/Controller/Entrepot/DatastoreController.php
+++ b/src/Controller/Entrepot/DatastoreController.php
@@ -9,8 +9,6 @@ use App\Dto\Datastore\UpdatePermissionDTO;
 use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\DatastoreApiService;
-use App\Services\EntrepotApi\ServiceAccount;
-use App\Services\SandboxService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -30,25 +28,7 @@ class DatastoreController extends AbstractController implements ApiControllerInt
 {
     public function __construct(
         private DatastoreApiService $datastoreApiService,
-        private SandboxService $sandboxService,
-        private ServiceAccount $serviceAccount,
     ) {
-    }
-
-    #[Route('/sandbox', name: 'get_sandbox', methods: ['GET'])]
-    public function getSandboxDatastore(): JsonResponse
-    {
-        try {
-            $sandboxCommunity = $this->serviceAccount->getSandboxCommunity();
-            $datastore = $sandboxCommunity['datastore'];
-
-            $datastore['is_sandbox'] = true;
-            $datastore['name'] = 'Découverte';
-
-            return $this->json($datastore);
-        } catch (ApiException $ex) {
-            throw new CartesApiException($ex->getMessage(), $ex->getStatusCode(), $ex->getDetails(), $ex);
-        }
     }
 
     #[Route('/{datastoreId}', name: 'get', methods: ['GET'])]
@@ -56,10 +36,6 @@ class DatastoreController extends AbstractController implements ApiControllerInt
     {
         try {
             $datastore = $this->datastoreApiService->get($datastoreId);
-            $datastore['is_sandbox'] = $this->sandboxService->isSandboxDatastore($datastore['_id']);
-            if (true === $datastore['is_sandbox']) {
-                $datastore['name'] = 'Découverte';
-            }
 
             return $this->json($datastore);
         } catch (ApiException $ex) {

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -47,35 +47,6 @@ class ServiceAccount
         $this->token = $this->getAccessToken();
     }
 
-    public function getSandboxCommunity(): ?array
-    {
-        if (!$this->token) {
-            return null;
-        }
-
-        if (!$this->sandBoxCommunityId) {
-            return null;
-        }
-
-        $options = $this->prepareOptions();
-
-        try {
-            $response = $this->apiClient->request('GET', "communities/{$this->sandBoxCommunityId}", $options);
-            $sandboxCommunity = $this->handleResponse($response);
-
-            $sandboxDatastoreId = $sandboxCommunity['datastore']['_id'];
-            $response = $this->apiClient->request('GET', "datastores/$sandboxDatastoreId", $options);
-            $sandboxDatastore = $this->handleResponse($response);
-
-            return [
-                'community' => $sandboxCommunity,
-                'datastore' => $sandboxDatastore,
-            ];
-        } catch (ApiException $e) {
-            return null;
-        }
-    }
-
     /**
      * Ajout de l'utilisateur courant (logge) a la communaute liee au datastore "Bac à sable".
      */

--- a/src/Services/SandboxService.php
+++ b/src/Services/SandboxService.php
@@ -62,21 +62,6 @@ class SandboxService
         return $processings['create_rast_pyr'];
     }
 
-    public function getSandboxCommunityId(): ?string
-    {
-        return $this->sandboxCommunityId;
-    }
-
-    public function isSandboxCommunity(string $CommunityId): bool
-    {
-        return null !== $this->sandboxCommunityId && $this->sandboxCommunityId === $CommunityId;
-    }
-
-    public function getSandboxDatastoreId(): ?string
-    {
-        return $this->sandboxDatastoreId;
-    }
-
     public function isSandboxDatastore(string $datastoreId): bool
     {
         return null !== $this->sandboxDatastoreId && $this->sandboxDatastoreId === $datastoreId;


### PR DESCRIPTION
## Quoi

Le champ `is_sandbox` était fabriqué par `DatastoreController`/`CommunityController` uniquement pour décorer les réponses API — le backend ne le lit jamais. Le frontend le dérive désormais de `sandboxCommunityId` (env) + `user_me.communities_member`, sans réseau.

- **Frontend** : `isSandboxCommunity()` dans la couche pure membership (+ vitest) ; `useMembership` expose `community` et `isSandbox` ; libellé d'entrepôt centralisé dans la clé de traduction `Common.datastore_name` (remplace les ternaires `is_sandbox ? tCommon("sandbox") : name` dispersés). Fil d'Ariane et 8 pages migrés.
- **Backend** : suppression du champ dans les 4 réponses, de l'override `name = 'Découverte'` (redondant : le libellé est déjà localisé côté front), de l'endpoint mort `/api/datastores/sandbox`, et des méthodes sans appelant (`ServiceAccount::getSandboxCommunity`, 3 méthodes `SandboxService`). `SandboxService` dé-injecté des deux contrôleurs → un accès `cache.app` par requête en moins sur ces routes.
- **Types** : `Datastore`/`Community` sans extension `is_sandbox` — toute lecture résiduelle casse à la compilation.

## Pourquoi

Plusieurs pages chargeaient le DTO complet uniquement pour le titre/libellé sandbox. Cette dérivation synchrone est le prérequis du chantier perf de chargement des pages (déférer la requête datastore là où elle ne porte pas le contenu principal).

## Vérification

- `type-check`, `lint`, vitest, `composer check-rules` verts ; `fosRoutes.json` régénéré.
- Runtime : entrepôt sandbox (titre/h1/fil d'Ariane/menu latéral « Espace Découverte », CallOut CSW de l'onglet métadonnées) et entrepôt normal sans régression ; réponses `/api/datastores/{id}` et `/api/community/{id}/` sans `is_sandbox`.
