### PR TITLE
feat: refonte fiche de données onglet flux #1117

### DIFF
--- a/assets/entrepot/pages/datasheet/DatasheetView/DatasetTabNext/DatasetTabNext.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/DatasetTabNext/DatasetTabNext.tsx
@@ -20,8 +20,9 @@ import RQKeys from "@/modules/entrepot/RQKeys";
 import { CartesApiException } from "@/modules/jsonFetch";
 import { routes } from "@/router/router";
 import { formatDateFromISO, getDatasheetPublicationsCount, parseIntegrationProgress } from "@/utils";
-import { deleteUploadConfirmModal } from "../DatasheetView/DatasheetViewNext";
 import useDeleteUploadMutation from "../../../../../hooks/queries/useDeleteUploadMutation";
+import DatasheetViewTab from "../../DatasheetViewTab";
+import { deleteUploadConfirmModal } from "../DatasheetView/DatasheetViewNext";
 import DatasetAddBanners from "./DatasetAddBanners";
 
 type DatasetType = "vector" | "raster";
@@ -210,14 +211,7 @@ export default function DatasetTabNext({ datastoreId, datasheetName }: DatasetTa
                 />
             )}
 
-            <div
-                className={cx(
-                    fr.cx("fr-container", "fr-py-4w"),
-                    css({
-                        backgroundColor: fr.colors.decisions.background.default.grey.default,
-                    })
-                )}
-            >
+            <DatasheetViewTab>
                 <h2 className={fr.cx("fr-h5", "fr-mb-10v")}>Données</h2>
 
                 <DatasetAddBanners />
@@ -294,7 +288,7 @@ export default function DatasetTabNext({ datastoreId, datasheetName }: DatasetTa
                         />
                     </>
                 )}
-            </div>
+            </DatasheetViewTab>
 
             {isDeletingUpload && (
                 <Wait>

--- a/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetViewNext.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetViewNext.tsx
@@ -4,6 +4,7 @@ import { useIsModalOpen } from "@codegouvfr/react-dsfr/Modal/useIsModalOpen";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { JSX, lazy, Suspense, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { useStyles } from "tss-react";
 
 import { DatasheetDetailed, Metadata, Service } from "@/@types/app";
 import DatasheetMain from "@/components/Layout/Datasheet/DatasheetMain";
@@ -17,13 +18,13 @@ import useCatalogueDatasheetUrl from "@/hooks/useCatalogueDatasheetUrl";
 import { useTranslation } from "@/i18n";
 import RQKeys from "@/modules/entrepot/RQKeys";
 import { CartesApiException } from "@/modules/jsonFetch";
-import { delta } from "@/utils";
 import { routes } from "@/router/router";
-import { useStyles } from "tss-react";
+import { delta } from "@/utils";
 import DatasheetHeader from "./DatasheetHeader";
 
 const DescriptionTab = lazy(() => import("../DescriptionTab/DescriptionTab"));
 const DatasetTabNext = lazy(() => import("../DatasetTabNext/DatasetTabNext"));
+const ServicesListTabNext = lazy(() => import("../ServiceListTab/ServicesListTabNext"));
 
 const publishConfirmModal = createModal({
     id: "datasheet-next-publish-confirm-modal",
@@ -48,24 +49,16 @@ export const deleteUploadConfirmModal = createModal({
 
 export enum DatasheetViewActiveTabEnum {
     Description = "description",
-    Preview = "preview",
     Annexes = "annexes",
     Dataset = "dataset",
-    Wfs = "wfs",
-    Wms = "wms",
-    Tms = "tms",
-    Wmts = "wmts",
+    Services = "services",
 }
 
 const tabs: Array<{ label: string; value: DatasheetViewActiveTabEnum }> = [
     { label: "Description", value: DatasheetViewActiveTabEnum.Description },
-    { label: "Aperçu", value: DatasheetViewActiveTabEnum.Preview },
     { label: "Annexes", value: DatasheetViewActiveTabEnum.Annexes },
     { label: "Données", value: DatasheetViewActiveTabEnum.Dataset },
-    { label: "Flux WFS", value: DatasheetViewActiveTabEnum.Wfs },
-    { label: "Flux WMS", value: DatasheetViewActiveTabEnum.Wms },
-    { label: "Flux TMS", value: DatasheetViewActiveTabEnum.Tms },
-    { label: "Flux WMTS", value: DatasheetViewActiveTabEnum.Wmts },
+    { label: "Flux", value: DatasheetViewActiveTabEnum.Services },
 ];
 
 type DatasheetViewProps = {
@@ -230,13 +223,9 @@ export default function DatasheetViewNext(props: DatasheetViewProps) {
                                 {(() => {
                                     const tabContent: Record<DatasheetViewActiveTabEnum, JSX.Element> = {
                                         [DatasheetViewActiveTabEnum.Description]: <DescriptionTab datastoreId={datastoreId} datasheetName={datasheetName} />,
-                                        [DatasheetViewActiveTabEnum.Preview]: <p>Aperçu</p>,
                                         [DatasheetViewActiveTabEnum.Annexes]: <p>Annexes</p>,
                                         [DatasheetViewActiveTabEnum.Dataset]: <DatasetTabNext datastoreId={datastoreId} datasheetName={datasheetName} />,
-                                        [DatasheetViewActiveTabEnum.Wfs]: <p>Flux WFS</p>,
-                                        [DatasheetViewActiveTabEnum.Wms]: <p>Flux WMS</p>,
-                                        [DatasheetViewActiveTabEnum.Tms]: <p>Flux TMS</p>,
-                                        [DatasheetViewActiveTabEnum.Wmts]: <p>Flux WMTS</p>,
+                                        [DatasheetViewActiveTabEnum.Services]: <ServicesListTabNext datastoreId={datastoreId} datasheetName={datasheetName} />,
                                     };
 
                                     return tabContent[activeTab as DatasheetViewActiveTabEnum] ?? <p>Onglet inconnu</p>;

--- a/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServiceInfoBanner.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServiceInfoBanner.tsx
@@ -1,0 +1,27 @@
+import Notice from "@codegouvfr/react-dsfr/Notice";
+import { useStyles } from "tss-react";
+
+type ServiceInfoBannerProps = {
+    title: string;
+    linkHref?: string;
+};
+
+export default function ServiceInfoBanner({ title, linkHref }: ServiceInfoBannerProps) {
+    const { css } = useStyles();
+
+    return (
+        <Notice
+            className={css({ borderRadius: 4 })}
+            severity="info"
+            title={title}
+            link={
+                linkHref !== undefined
+                    ? {
+                          text: "En savoir plus",
+                          linkProps: { href: linkHref },
+                      }
+                    : undefined
+            }
+        />
+    );
+}

--- a/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListItem.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListItem.tsx
@@ -3,7 +3,6 @@ import Alert from "@codegouvfr/react-dsfr/Alert";
 import Button from "@codegouvfr/react-dsfr/Button";
 import { createModal } from "@codegouvfr/react-dsfr/Modal";
 import { useToggle } from "@mantine/hooks";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FC } from "react";
 import { createPortal } from "react-dom";
 import { symToStr } from "tsafe/symToStr";
@@ -11,15 +10,13 @@ import { symToStr } from "tsafe/symToStr";
 import { CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
 import { TextCopyToClipboardDialog, TextCopyToClipboardModal } from "@/components/Utils/TextCopyToClipboardDialog";
 import useCommunityRights from "@/hooks/useCommunityRights";
-import { CartesApiException } from "@/modules/jsonFetch";
+import useUnpublishServiceMutation from "@/hooks/queries/useUnpublishServiceMutation";
 import { useSnackbarStore } from "@/stores/SnackbarStore";
-import { OfferingStatusEnum, OfferingTypeEnum, StoredDataTypeEnum, type Service } from "../../../../../@types/app";
+import { OfferingStatusEnum, OfferingTypeEnum, type Service } from "../../../../../@types/app";
 import OfferingStatusBadge from "../../../../../components/Utils/Badges/OfferingStatusBadge";
 import Wait from "../../../../../components/Utils/Wait";
-import RQKeys from "../../../../../modules/entrepot/RQKeys";
 import { routes } from "../../../../../router/router";
-import { offeringTypeDisplayName } from "../../../../../utils";
-import api from "../../../../api";
+import { editableOfferingTypes, getServiceEditLink, offeringTypeDisplayName } from "../../../../../utils";
 import ListItem from "../ListItem";
 import ServiceDesc from "./ServiceDesc";
 
@@ -29,7 +26,6 @@ type ServicesListItemProps = {
     datasheetName: string;
 };
 const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, datastoreId }) => {
-    const queryClient = useQueryClient();
     const setMessage = useSnackbarStore((state) => state.setMessage);
 
     const unpublishServiceConfirmModal = createModal({
@@ -37,27 +33,7 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
         isOpenedByDefault: false,
     });
 
-    const unpublishServiceMutation = useMutation<null, CartesApiException, Service>({
-        mutationFn: (service: Service) => {
-            if (![OfferingTypeEnum.WFS, OfferingTypeEnum.WMSVECTOR, OfferingTypeEnum.WMSRASTER, OfferingTypeEnum.WMTSTMS].includes(service.type)) {
-                console.warn(`Dépublication de service ${service.type} n'a pas encore été implémentée`);
-                return Promise.reject(`Dépublication de service ${service.type} n'a pas encore été implémentée`);
-            }
-
-            return api.service.unpublishService(datastoreId, service._id);
-        },
-        onSuccess() {
-            queryClient.setQueryData(
-                RQKeys.datastore_datasheet_service_list(datastoreId, datasheetName),
-                (servicesList: Service[] | undefined): Service[] | undefined => {
-                    return servicesList?.filter((s) => s._id !== service._id);
-                }
-            );
-
-            queryClient.refetchQueries({ queryKey: RQKeys.datastore_datasheet(datastoreId, datasheetName) });
-            queryClient.refetchQueries({ queryKey: RQKeys.datastore_datasheet_metadata(datastoreId, datasheetName) });
-        },
-    });
+    const unpublishServiceMutation = useUnpublishServiceMutation(datastoreId, datasheetName);
 
     const [showDescription, toggleShowDescription] = useToggle();
 
@@ -109,61 +85,11 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
                         linkProps: routes.datastore_manage_permissions({ datastoreId }).link,
                         disabled: service.open === true,
                     },
-                    [OfferingTypeEnum.WMSVECTOR, OfferingTypeEnum.WMSRASTER, OfferingTypeEnum.WFS, OfferingTypeEnum.WMTSTMS].includes(service.type) &&
+                    editableOfferingTypes.includes(service.type) &&
                         (isSupervisor || userRights?.includes(CommunityMemberDtoRightsEnum.BROADCAST)) && {
                             text: "Modifier les informations de publication",
                             iconId: "ri-edit-box-line",
-                            linkProps: (() => {
-                                switch (service.type) {
-                                    case OfferingTypeEnum.WMSVECTOR:
-                                        return routes.datastore_wms_vector_service_edit({
-                                            datastoreId,
-                                            vectorDbId: service.configuration.type_infos.used_data[0].stored_data,
-                                            offeringId: service._id,
-                                            datasheetName,
-                                        }).link;
-
-                                    case OfferingTypeEnum.WMSRASTER:
-                                        return routes.datastore_pyramid_raster_wms_raster_service_edit({
-                                            datastoreId,
-                                            pyramidId: service.configuration.type_infos.used_data[0].stored_data,
-                                            offeringId: service._id,
-                                            datasheetName,
-                                        }).link;
-
-                                    case OfferingTypeEnum.WFS:
-                                        return routes.datastore_wfs_service_edit({
-                                            datastoreId,
-                                            vectorDbId: service.configuration.type_infos.used_data[0].stored_data,
-                                            offeringId: service._id,
-                                            datasheetName,
-                                        }).link;
-
-                                    case OfferingTypeEnum.WMTSTMS:
-                                        switch (service.configuration.pyramid?.type) {
-                                            case StoredDataTypeEnum.ROK4PYRAMIDVECTOR:
-                                                return routes.datastore_pyramid_vector_tms_service_edit({
-                                                    datastoreId,
-                                                    pyramidId: service.configuration.type_infos.used_data[0].stored_data,
-                                                    offeringId: service._id,
-                                                    datasheetName,
-                                                }).link;
-                                            case StoredDataTypeEnum.ROK4PYRAMIDRASTER:
-                                                return routes.datastore_pyramid_raster_wmts_service_edit({
-                                                    datastoreId,
-                                                    pyramidId: service.configuration.type_infos.used_data[0].stored_data,
-                                                    offeringId: service._id,
-                                                    datasheetName,
-                                                }).link;
-
-                                            default:
-                                                return routes.page_not_found().link;
-                                        }
-
-                                    default:
-                                        return routes.page_not_found().link;
-                                }
-                            })(),
+                            linkProps: getServiceEditLink(datastoreId, datasheetName, service),
                         },
                     service.type === OfferingTypeEnum.WMSVECTOR &&
                         (isSupervisor || userRights?.includes(CommunityMemberDtoRightsEnum.PROCESSING)) && {

--- a/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListTabNext.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListTabNext.tsx
@@ -1,0 +1,312 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import Alert from "@codegouvfr/react-dsfr/Alert";
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { createModal } from "@codegouvfr/react-dsfr/Modal";
+import Pagination from "@codegouvfr/react-dsfr/Pagination";
+import { SegmentedControl } from "@codegouvfr/react-dsfr/SegmentedControl";
+import Table from "@codegouvfr/react-dsfr/Table";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useStyles } from "tss-react";
+
+import { OfferingTypeEnum, StoredDataTypeEnum, type Service } from "@/@types/app";
+import { CommunityMemberDtoRightsEnum } from "@/@types/entrepot";
+import OfferingStatusBadge from "@/components/Utils/Badges/OfferingStatusBadge";
+import LoadingText from "@/components/Utils/LoadingText";
+import MenuList from "@/components/Utils/MenuList";
+import { TextCopyToClipboardDialog, TextCopyToClipboardModal } from "@/components/Utils/TextCopyToClipboardDialog";
+import Wait from "@/components/Utils/Wait";
+import api from "@/entrepot/api";
+import useCommunityRights from "@/hooks/useCommunityRights";
+import { usePagination } from "@/hooks/usePagination";
+import useUnpublishServiceMutation from "@/hooks/queries/useUnpublishServiceMutation";
+import placeholder1x1 from "@/img/placeholder.1x1.png";
+import RQKeys from "@/modules/entrepot/RQKeys";
+import { CartesApiException } from "@/modules/jsonFetch";
+import { routes } from "@/router/router";
+import { useSnackbarStore } from "@/stores/SnackbarStore";
+import { editableOfferingTypes, formatDateFromISO, getServiceEditLink } from "@/utils";
+import DatasheetViewTab from "../../DatasheetViewTab";
+import ServiceInfoBanner from "./ServiceInfoBanner";
+
+const LIMIT = 10;
+
+const unpublishServiceConfirmModal = createModal({
+    id: "services-tab-next-unpublish-service-confirm-modal",
+    isOpenedByDefault: false,
+});
+
+type ServiceTypeFilter = "all" | "wfs" | "wms" | "wmts" | "tms";
+
+// un WMTS-TMS dont le type de pyramide est inconnu apparaît sous WMTS et TMS
+function matchesTypeFilter(service: Service, filter: ServiceTypeFilter): boolean {
+    switch (filter) {
+        case "all":
+            return true;
+        case "wfs":
+            return service.type === OfferingTypeEnum.WFS;
+        case "wms":
+            return service.type === OfferingTypeEnum.WMSVECTOR || service.type === OfferingTypeEnum.WMSRASTER;
+        case "wmts":
+            return service.type === OfferingTypeEnum.WMTSTMS && service.configuration.pyramid?.type !== StoredDataTypeEnum.ROK4PYRAMIDVECTOR;
+        case "tms":
+            return service.type === OfferingTypeEnum.WMTSTMS && service.configuration.pyramid?.type !== StoredDataTypeEnum.ROK4PYRAMIDRASTER;
+    }
+}
+
+type ServicesListTabNextProps = {
+    datastoreId: string;
+    datasheetName: string;
+};
+
+export default function ServicesListTabNext({ datastoreId, datasheetName }: ServicesListTabNextProps) {
+    const [typeFilter, setTypeFilter] = useState<ServiceTypeFilter>("all");
+    const [page, setPage] = useState(1);
+    const [targetService, setTargetService] = useState<Service>();
+
+    const setMessage = useSnackbarStore((state) => state.setMessage);
+    const { userRights, isSupervisor } = useCommunityRights();
+    const canBroadcast = isSupervisor || userRights?.includes(CommunityMemberDtoRightsEnum.BROADCAST);
+
+    // Récupération des services — dédupliquée par React Query avec la query identique du composant parent
+    const serviceListQuery = useQuery<Service[], CartesApiException>({
+        queryKey: RQKeys.datastore_datasheet_service_list(datastoreId, datasheetName),
+        queryFn: ({ signal }) => api.datasheet.getServices(datastoreId, datasheetName, { signal }),
+        staleTime: 60000,
+        retry: false,
+    });
+
+    const unpublishServiceMutation = useUnpublishServiceMutation(datastoreId, datasheetName);
+
+    // du plus récent au plus ancien
+    const sortedServices = useMemo(
+        () => [...(serviceListQuery.data ?? [])].sort((a, b) => (b.configuration.last_event?.date ?? "").localeCompare(a.configuration.last_event?.date ?? "")),
+        [serviceListQuery.data]
+    );
+
+    const filteredServices = useMemo(() => sortedServices.filter((service) => matchesTypeFilter(service, typeFilter)), [sortedServices, typeFilter]);
+
+    const typeFilterSegment = (filter: ServiceTypeFilter, label: string) => ({
+        label,
+        nativeInputProps: {
+            checked: typeFilter === filter,
+            onChange: () => {
+                setTypeFilter(filter);
+                setPage(1);
+            },
+        },
+    });
+
+    const { paginatedItems: pageServices, totalPages: pageCount } = usePagination(filteredServices, page, LIMIT);
+
+    const { css, cx } = useStyles();
+
+    // lignes mémorisées : références stables pour que memo(MenuList) évite de re-rendre les menus de chaque ligne
+    const rows = useMemo(
+        () =>
+            pageServices.map((service) => [
+                <img
+                    key={`thumbnail-${service._id}`}
+                    src={placeholder1x1}
+                    alt=""
+                    className={css({ width: 40, height: 40, objectFit: "cover", borderRadius: 4, display: "block" })}
+                />,
+                service.layer_name,
+                service.configuration.last_event?.date ? formatDateFromISO(service.configuration.last_event.date) : "",
+                <Badge key={`access-${service._id}`} small noIcon className={fr.cx(service.open ? "fr-badge--blue-cumulus" : "fr-badge--purple-glycine")}>
+                    {service.open ? "Public" : "Privé"}
+                </Badge>,
+                <OfferingStatusBadge key={`status-${service._id}`} status={service.status} />,
+                <Button
+                    key={`consult-${service._id}`}
+                    priority="secondary"
+                    size="small"
+                    linkProps={routes.datastore_service_view({ datastoreId, offeringId: service._id, datasheetName }).link}
+                >
+                    Consulter
+                </Button>,
+                <MenuList
+                    key={`menu-${service._id}`}
+                    menuOpenButtonProps={{
+                        iconId: "ri-more-2-line",
+                        priority: "tertiary no outline",
+                        title: "Autres actions",
+                        size: "small",
+                    }}
+                    items={[
+                        {
+                            text: "Copier l’URL",
+                            iconId: "ri-file-copy-line",
+                            onClick: () => {
+                                if (!service.share_url) {
+                                    setMessage("URL de diffusion indisponible");
+                                } else {
+                                    setTargetService(service);
+                                    TextCopyToClipboardModal.open();
+                                }
+                            },
+                        },
+                        {
+                            text: "Voir dans cartes.gouv.fr",
+                            iconId: "ri-external-link-line",
+                            disabled: true,
+                            onClick: () => {},
+                        },
+                        editableOfferingTypes.includes(service.type) &&
+                            canBroadcast && {
+                                text: "Mettre à jour",
+                                iconId: "ri-edit-box-line",
+                                linkProps: getServiceEditLink(datastoreId, datasheetName, service),
+                            },
+                        canBroadcast && {
+                            text: "Dépublier",
+                            iconId: "ri-arrow-go-back-line",
+                            onClick: () => {
+                                setTargetService(service);
+                                unpublishServiceConfirmModal.open();
+                            },
+                        },
+                        {
+                            text: "Supprimer",
+                            iconId: "ri-delete-bin-line",
+                            disabled: true,
+                            onClick: () => {},
+                        },
+                    ]}
+                />,
+            ]),
+        [pageServices, canBroadcast, datastoreId, datasheetName, css, setMessage]
+    );
+
+    if (serviceListQuery.isLoading) {
+        return <LoadingText withSpinnerIcon={true} as="p" />;
+    }
+
+    if (serviceListQuery.isError) {
+        return <Alert severity="error" title="Erreur lors du chargement des services" description={serviceListQuery.error.message} closable={false} />;
+    }
+
+    return (
+        <>
+            <DatasheetViewTab>
+                <h2 className={fr.cx("fr-h5", "fr-mb-4w")}>Flux</h2>
+
+                <ServiceInfoBanner title="Chaque type de flux est adapté à un besoin particulier. Renseignez-vous avant de publier." linkHref="#" />
+
+                {sortedServices.length === 0 ? (
+                    <div
+                        className={cx(
+                            fr.cx("fr-mt-4w", "fr-py-8w"),
+                            css({
+                                display: "flex",
+                                justifyContent: "center",
+                                border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
+                            })
+                        )}
+                    >
+                        <Button linkProps={routes.datastore_service_add_next({ datastoreId, datasheetName }).link}>Créer un flux</Button>
+                    </div>
+                ) : (
+                    <>
+                        <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-mt-4w")}>
+                            <div className={fr.cx("fr-col")}>
+                                <SegmentedControl
+                                    hideLegend
+                                    legend="Filtrer par type de flux"
+                                    name="service-type-filter"
+                                    segments={[
+                                        typeFilterSegment("all", "Tous"),
+                                        typeFilterSegment("wfs", "WFS"),
+                                        typeFilterSegment("wms", "WMS"),
+                                        typeFilterSegment("wmts", "WMTS"),
+                                        typeFilterSegment("tms", "TMS"),
+                                    ]}
+                                />
+                            </div>
+                            <div className={css({ marginLeft: "auto", display: "flex", gap: fr.spacing("2v") })}>
+                                {/* TODO : parcours de génération de flux à brancher (refonte) */}
+                                <Button priority="secondary" disabled>
+                                    Ajouter un flux existant
+                                </Button>
+                                <Button linkProps={routes.datastore_service_add_next({ datastoreId, datasheetName }).link}>Créer un flux</Button>
+                            </div>
+                        </div>
+
+                        <div className={cx(fr.cx("fr-mt-3w", "fr-mb-1w"), css({ display: "flex", justifyContent: "space-between" }))}>
+                            <p className={fr.cx("fr-text--sm", "fr-m-0")}>
+                                {filteredServices.length} résultat{filteredServices.length > 1 ? "s" : ""}
+                            </p>
+                            <p className={fr.cx("fr-text--sm", "fr-m-0")}>{LIMIT} résultats par page</p>
+                        </div>
+
+                        <Table
+                            className={css({ "& table": { width: "100%" } })}
+                            caption="Flux"
+                            noCaption
+                            headers={["", "Flux", "Date de publication", "Accès", "Statut", "Action", ""]}
+                            data={rows}
+                        />
+
+                        {pageCount > 1 && (
+                            <div className={fr.cx("fr-grid-row", "fr-grid-row--center", "fr-mt-4w")}>
+                                <Pagination
+                                    count={pageCount}
+                                    defaultPage={page}
+                                    showFirstLast
+                                    getPageLinkProps={(pageNumber) => ({
+                                        href: "#",
+                                        onClick: (e) => {
+                                            e.preventDefault();
+                                            setPage(pageNumber);
+                                        },
+                                    })}
+                                />
+                            </div>
+                        )}
+                    </>
+                )}
+            </DatasheetViewTab>
+
+            {/* Modale : Dépublier un service */}
+            {createPortal(
+                <unpublishServiceConfirmModal.Component
+                    title={`Êtes-vous sûr de dépublier le service ${targetService?.type ?? ""} ?`}
+                    buttons={[
+                        {
+                            children: "Non, annuler",
+                            doClosesModal: true,
+                            priority: "secondary",
+                        },
+                        {
+                            children: "Oui, dépublier",
+                            onClick: () => targetService && unpublishServiceMutation.mutate(targetService),
+                            doClosesModal: true,
+                            priority: "primary",
+                        },
+                    ]}
+                >
+                    <strong>Les éléments suivants seront supprimés :</strong>
+                    <ul>
+                        <li>1 offre ({targetService?._id})</li>
+                        <li>1 configuration ({targetService?.configuration._id})</li>
+                    </ul>
+                </unpublishServiceConfirmModal.Component>,
+                document.body
+            )}
+
+            {unpublishServiceMutation.isPending && (
+                <Wait>
+                    <div className={fr.cx("fr-grid-row")}>
+                        <LoadingText as="h6" message="En cours de dépublication" withSpinnerIcon={true} />
+                    </div>
+                </Wait>
+            )}
+
+            {unpublishServiceMutation.error && <Alert severity="error" closable title={unpublishServiceMutation.error.message} />}
+
+            <TextCopyToClipboardDialog title="Copier l’URL" label="URL de diffusion" text={targetService?.share_url ?? ""} />
+        </>
+    );
+}

--- a/assets/entrepot/pages/datasheet/DatasheetViewTab.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetViewTab.tsx
@@ -1,0 +1,25 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { PropsWithChildren } from "react";
+import { useStyles } from "tss-react";
+
+type ContentCardProps = PropsWithChildren<{
+    className?: string;
+}>;
+
+export default function DatasheetViewTab({ children, className }: ContentCardProps) {
+    const { css, cx } = useStyles();
+
+    return (
+        <div
+            className={cx(
+                fr.cx("fr-container", "fr-py-4w"),
+                css({
+                    backgroundColor: fr.colors.decisions.background.default.grey.default,
+                }),
+                className
+            )}
+        >
+            {children}
+        </div>
+    );
+}

--- a/assets/entrepot/pages/datasheet/ServiceCreate/ServiceCreate.tsx
+++ b/assets/entrepot/pages/datasheet/ServiceCreate/ServiceCreate.tsx
@@ -1,0 +1,9 @@
+import ServiceTypeSelection from "./ServiceTypeSelection";
+
+type ServiceCreateProps = {
+    datastoreId: string;
+    datasheetName: string;
+};
+export default function ServiceCreate(_props: ServiceCreateProps) {
+    return <ServiceTypeSelection />;
+}

--- a/assets/entrepot/pages/datasheet/ServiceCreate/ServiceTypeSelection.tsx
+++ b/assets/entrepot/pages/datasheet/ServiceCreate/ServiceTypeSelection.tsx
@@ -1,0 +1,30 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import Select, { type SelectProps } from "@codegouvfr/react-dsfr/SelectNext";
+import { useState } from "react";
+
+import { OfferingTypeEnum } from "@/@types/app";
+import DatasheetViewTab from "../DatasheetViewTab";
+import ServiceInfoBanner from "../DatasheetView/ServiceListTab/ServiceInfoBanner";
+
+const serviceTypeOptions: SelectProps.Option<OfferingTypeEnum | "">[] = [{ value: OfferingTypeEnum.WFS, label: "Flux WFS" }];
+
+export default function ServiceTypeSelection() {
+    const [selectedType, setSelectedType] = useState<OfferingTypeEnum | "">("");
+
+    return (
+        <DatasheetViewTab>
+            <ServiceInfoBanner title="Chaque type de flux est adapté à un besoin particulier. Renseignez-vous avant de publier." linkHref="#" />
+
+            <Select
+                className={fr.cx("fr-mt-4w")}
+                label="Type de service"
+                placeholder="Sélectionner une option"
+                options={serviceTypeOptions}
+                nativeSelectProps={{
+                    value: selectedType,
+                    onChange: (e) => setSelectedType(e.target.value),
+                }}
+            />
+        </DatasheetViewTab>
+    );
+}

--- a/assets/hooks/queries/useUnpublishServiceMutation.ts
+++ b/assets/hooks/queries/useUnpublishServiceMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { type Service } from "@/@types/app";
+import api from "@/entrepot/api";
+import RQKeys from "@/modules/entrepot/RQKeys";
+import { CartesApiException } from "@/modules/jsonFetch";
+import { editableOfferingTypes } from "@/utils";
+
+export default function useUnpublishServiceMutation(datastoreId: string, datasheetName: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation<null, CartesApiException, Service>({
+        mutationFn: (service) => {
+            if (!editableOfferingTypes.includes(service.type)) {
+                return Promise.reject(`Dépublication de service ${service.type} n’a pas encore été implémentée`);
+            }
+
+            return api.service.unpublishService(datastoreId, service._id);
+        },
+        onSuccess(_, service) {
+            queryClient.setQueryData(
+                RQKeys.datastore_datasheet_service_list(datastoreId, datasheetName),
+                (servicesList: Service[] | undefined): Service[] | undefined => servicesList?.filter((s) => s._id !== service._id)
+            );
+
+            queryClient.refetchQueries({ queryKey: RQKeys.datastore_datasheet(datastoreId, datasheetName) });
+            queryClient.refetchQueries({ queryKey: RQKeys.datastore_datasheet_metadata(datastoreId, datasheetName) });
+        },
+    });
+}

--- a/assets/router/GroupDatastore.tsx
+++ b/assets/router/GroupDatastore.tsx
@@ -16,6 +16,7 @@ const DatasheetView = lazy(() => import("../entrepot/pages/datasheet/DatasheetVi
 const DatasheetViewNext = lazy(() => import("../entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetViewNext"));
 const DatasheetCreateNext = lazy(() => import("../entrepot/pages/datasheet/DatasheetCreate/DatasheetCreateNext"));
 const DatasetAddPage = lazy(() => import("../entrepot/pages/datasheet/DatasetAdd/DatasetAddPage"));
+const ServiceCreate = lazy(() => import("../entrepot/pages/datasheet/ServiceCreate/ServiceCreate"));
 const StoredDataDetails = lazy(() => import("../entrepot/pages/data_details/StoredDataDetails"));
 const UploadDetails = lazy(() => import("../entrepot/pages/data_details/UploadDetails"));
 const WfsServiceForm = lazy(() => import("../entrepot/pages/service/wfs/WfsServiceForm"));
@@ -93,6 +94,10 @@ function GroupDatastore(props: IGroupDatastoreProps) {
             case "datastore_dataset_add_next":
                 return {
                     render: <DatasetAddPage datastoreId={route.params.datastoreId} datasheetName={route.params.datasheetName} />,
+                };
+            case "datastore_service_add_next":
+                return {
+                    render: <ServiceCreate datastoreId={route.params.datastoreId} datasheetName={route.params.datasheetName} />,
                 };
             case "datastore_stored_data_details":
                 return {

--- a/assets/router/router.ts
+++ b/assets/router/router.ts
@@ -164,6 +164,13 @@ const datastoreRoutes = {
         },
         (p) => `/donnees/${p.datasheetName}/next/ajouter`
     ),
+    datastore_service_add_next: datastoreRoute.extend(
+        {
+            datasheetName: param.path.string,
+        },
+        (p) => `/donnees/${p.datasheetName}/next/service/ajout`
+    ),
+
     datastore_stored_data_details: datastoreRoute.extend(
         {
             storedDataId: param.path.string,

--- a/assets/utils/offering.ts
+++ b/assets/utils/offering.ts
@@ -1,4 +1,64 @@
-import { OfferingTypeEnum } from "@/@types/app";
+import { OfferingTypeEnum, StoredDataTypeEnum, type Service } from "@/@types/app";
+import { routes } from "@/router/router";
+
+export const editableOfferingTypes: OfferingTypeEnum[] = [
+    OfferingTypeEnum.WFS,
+    OfferingTypeEnum.WMSVECTOR,
+    OfferingTypeEnum.WMSRASTER,
+    OfferingTypeEnum.WMTSTMS,
+];
+
+export function getServiceEditLink(datastoreId: string, datasheetName: string, service: Service) {
+    switch (service.type) {
+        case OfferingTypeEnum.WMSVECTOR:
+            return routes.datastore_wms_vector_service_edit({
+                datastoreId,
+                vectorDbId: service.configuration.type_infos.used_data[0].stored_data,
+                offeringId: service._id,
+                datasheetName,
+            }).link;
+
+        case OfferingTypeEnum.WMSRASTER:
+            return routes.datastore_pyramid_raster_wms_raster_service_edit({
+                datastoreId,
+                pyramidId: service.configuration.type_infos.used_data[0].stored_data,
+                offeringId: service._id,
+                datasheetName,
+            }).link;
+
+        case OfferingTypeEnum.WFS:
+            return routes.datastore_wfs_service_edit({
+                datastoreId,
+                vectorDbId: service.configuration.type_infos.used_data[0].stored_data,
+                offeringId: service._id,
+                datasheetName,
+            }).link;
+
+        case OfferingTypeEnum.WMTSTMS:
+            switch (service.configuration.pyramid?.type) {
+                case StoredDataTypeEnum.ROK4PYRAMIDVECTOR:
+                    return routes.datastore_pyramid_vector_tms_service_edit({
+                        datastoreId,
+                        pyramidId: service.configuration.type_infos.used_data[0].stored_data,
+                        offeringId: service._id,
+                        datasheetName,
+                    }).link;
+                case StoredDataTypeEnum.ROK4PYRAMIDRASTER:
+                    return routes.datastore_pyramid_raster_wmts_service_edit({
+                        datastoreId,
+                        pyramidId: service.configuration.type_infos.used_data[0].stored_data,
+                        offeringId: service._id,
+                        datasheetName,
+                    }).link;
+
+                default:
+                    return routes.page_not_found().link;
+            }
+
+        default:
+            return routes.page_not_found().link;
+    }
+}
 
 export const offeringTypeDisplayName = (type: OfferingTypeEnum): string => {
     switch (type) {


### PR DESCRIPTION
## Quoi

- Nouvel onglet « Flux » de la vue fiche de données (refonte) : liste unique des services publiés (vignette, date de publication, accès public/privé, statut, actions), filtres par type (Tous / WFS / WMS / WMTS / TMS), pagination côté client (10 par page), état vide avec bouton « Créer un flux ».
- Ébauche de la page de création de service (bannière d'information + sélecteur de type) et route `datastore_service_add_next`.
- Helpers extraits et partagés avec l'ancienne liste : `getServiceEditLink` (routes de modification par type), `useUnpublishServiceMutation` (dépublication + mise à jour du cache), conteneur `DatasheetViewTab`.

## Notes

- « Ajouter un flux existant », « Voir dans cartes.gouv.fr » et « Supprimer » sont désactivés pour l'instant (parcours à venir).
- WMTS et TMS sont distingués par le type de pyramide (`configuration.pyramid.type`) ; un WMTS-TMS au type de pyramide inconnu apparaît dans les deux filtres.