### PR TITLE
feat: ajustements après changement API, 2 DELETE pour supprimer une offering

### DIFF
--- a/assets/@types/entrepot.ts
+++ b/assets/@types/entrepot.ts
@@ -5003,6 +5003,7 @@ export enum OfferingStandardDetailResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -5368,6 +5369,7 @@ export enum PermissionOfferingResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -5632,6 +5634,7 @@ export enum OfferingStandardListResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -5729,6 +5732,7 @@ export enum OfferingExtendedListResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -5911,6 +5915,7 @@ export enum OfferingCatalogResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -5974,6 +5979,7 @@ export enum OfferingExtendedDetailResponseDtoStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -6454,6 +6460,7 @@ export enum GetOfferingsParamsStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -6597,6 +6604,7 @@ export enum GetAll8ParamsStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 
@@ -6800,6 +6808,7 @@ export enum GetAll23ParamsStatusEnum {
     MODIFYING = "MODIFYING",
     PUBLISHED = "PUBLISHED",
     UNPUBLISHING = "UNPUBLISHING",
+    UNPUBLISHED = "UNPUBLISHED",
     UNSTABLE = "UNSTABLE",
 }
 

--- a/assets/components/Utils/Badges/OfferingStatusBadge.tsx
+++ b/assets/components/Utils/Badges/OfferingStatusBadge.tsx
@@ -42,6 +42,11 @@ const OfferingStatusBadge: FC<OfferingStatusBadgeProps> = ({ status }) => {
                 );
                 break;
 
+            case OfferingStatusEnum.UNPUBLISHED:
+                severity = "info";
+                text = "Dépublié";
+                break;
+
             case OfferingStatusEnum.MODIFYING:
                 severity = "warning";
                 text = (

--- a/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetView.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/DatasheetView/DatasheetView.tsx
@@ -334,7 +334,7 @@ const DatasheetView: FC<DatasheetViewProps> = ({ datastoreId, datasheetName }) =
                                         <li>{datasheetQuery?.data?.pyramid_raster_list.length} pyramide(s) de tuiles raster</li>
                                     ) : null}
                                     {serviceListQuery.data?.length && serviceListQuery.data.length > 0 ? (
-                                        <li>{serviceListQuery.data.length} service(s) publié(s)</li>
+                                        <li>{serviceListQuery.data.length} service(s)</li>
                                     ) : null}
                                     {datasheetQuery?.data?.upload_list?.length && datasheetQuery?.data?.upload_list.length > 0 ? (
                                         <li>{datasheetQuery?.data?.upload_list.length} livraison(s)</li>

--- a/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListItem.tsx
+++ b/assets/entrepot/pages/datasheet/DatasheetView/ServiceListTab/ServicesListItem.tsx
@@ -13,12 +13,12 @@ import { TextCopyToClipboardDialog, TextCopyToClipboardModal } from "@/component
 import useCommunityRights from "@/hooks/useCommunityRights";
 import { CartesApiException } from "@/modules/jsonFetch";
 import { useSnackbarStore } from "@/stores/SnackbarStore";
-import { OfferingStatusEnum, OfferingTypeEnum, StoredDataTypeEnum, type Service } from "../../../../../@types/app";
+import { OfferingTypeEnum, StoredDataTypeEnum, type Service } from "../../../../../@types/app";
 import OfferingStatusBadge from "../../../../../components/Utils/Badges/OfferingStatusBadge";
 import Wait from "../../../../../components/Utils/Wait";
 import RQKeys from "../../../../../modules/entrepot/RQKeys";
 import { routes } from "../../../../../router/router";
-import { offeringTypeDisplayName } from "../../../../../utils";
+import { isOfferingUnavailable, offeringTypeDisplayName } from "../../../../../utils";
 import api from "../../../../api";
 import ListItem from "../ListItem";
 import ServiceDesc from "./ServiceDesc";
@@ -63,19 +63,23 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
 
     const { userRights, isSupervisor } = useCommunityRights();
 
+    const offeringUnavailable = isOfferingUnavailable(service.status);
+
     return (
         <>
             <ListItem
                 actionButton={
                     <Button
                         className={fr.cx("fr-mr-2v")}
-                        linkProps={routes.datastore_service_view({ datastoreId, offeringId: service._id, datasheetName: datasheetName }).link}
                         priority="secondary"
+                        {...(offeringUnavailable
+                            ? { disabled: true }
+                            : { linkProps: routes.datastore_service_view({ datastoreId, offeringId: service._id, datasheetName: datasheetName }).link })}
                     >
                         Visualiser
                     </Button>
                 }
-                badge={<OfferingStatusBadge status={service.status as OfferingStatusEnum} />}
+                badge={<OfferingStatusBadge status={service.status} />}
                 buttonTitle="Voir les données liées"
                 date={service?.configuration?.last_event?.date}
                 menuListItems={[
@@ -83,6 +87,7 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
                         autoClose: false,
                         text: "Copier l’URL de diffusion",
                         iconId: "ri-file-copy-line",
+                        disabled: offeringUnavailable,
                         onClick: async () => {
                             if (!service.share_url) {
                                 setMessage("URL de diffusion indisponible");
@@ -96,6 +101,7 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
                             (userRights?.includes(CommunityMemberDtoRightsEnum.ANNEX) && userRights?.includes(CommunityMemberDtoRightsEnum.BROADCAST))) && {
                             text: "Gérer les styles",
                             iconId: "ri-flashlight-line",
+                            disabled: offeringUnavailable,
                             linkProps: routes.datastore_service_view({ datastoreId, datasheetName, offeringId: service._id }).link,
                         },
                     // {
@@ -107,12 +113,13 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
                         text: "Gérer les permissions d’accès",
                         iconId: "ri-lock-line",
                         linkProps: routes.datastore_manage_permissions({ datastoreId }).link,
-                        disabled: service.open === true,
+                        disabled: service.open === true || offeringUnavailable,
                     },
                     [OfferingTypeEnum.WMSVECTOR, OfferingTypeEnum.WMSRASTER, OfferingTypeEnum.WFS, OfferingTypeEnum.WMTSTMS].includes(service.type) &&
                         (isSupervisor || userRights?.includes(CommunityMemberDtoRightsEnum.BROADCAST)) && {
                             text: "Modifier les informations de publication",
                             iconId: "ri-edit-box-line",
+                            disabled: offeringUnavailable,
                             linkProps: (() => {
                                 switch (service.type) {
                                     case OfferingTypeEnum.WMSVECTOR:
@@ -169,6 +176,7 @@ const ServicesListItem: FC<ServicesListItemProps> = ({ service, datasheetName, d
                         (isSupervisor || userRights?.includes(CommunityMemberDtoRightsEnum.PROCESSING)) && {
                             text: "Créer un service raster WMS/WMTS",
                             iconId: "ri-add-box-line",
+                            disabled: offeringUnavailable,
                             linkProps: routes.datastore_pyramid_raster_generate({ datastoreId, offeringId: service._id, datasheetName }).link,
                         },
                     // NOTE : reporté cf. issue #249

--- a/assets/entrepot/pages/datastore/ManagePermissions/AddPermissionForm.tsx
+++ b/assets/entrepot/pages/datastore/ManagePermissions/AddPermissionForm.tsx
@@ -20,6 +20,7 @@ import Wait from "../../../../components/Utils/Wait";
 import { useTranslation } from "../../../../i18n/i18n";
 import RQKeys from "../../../../modules/entrepot/RQKeys";
 import { routes } from "../../../../router/router";
+import { isOfferingUnavailable } from "../../../../utils";
 import "../../../../sass/pages/permission.scss";
 import api from "../../../api";
 import CommunityListForm from "./CommunityListForm";
@@ -94,7 +95,7 @@ const AddPermissionForm: FC<AddPermissionFormProps> = ({ datastoreId }) => {
     }, [user, publicCommunities]);
 
     const privateOfferings = useMemo(() => {
-        return data?.filter((offering) => offering.open === false) ?? [];
+        return data?.filter((offering) => offering.open === false && !isOfferingUnavailable(offering.status)) ?? [];
     }, [data]);
 
     // Formulaire,

--- a/assets/entrepot/pages/service/view/ServiceView.tsx
+++ b/assets/entrepot/pages/service/view/ServiceView.tsx
@@ -9,6 +9,7 @@ import Main from "../../../../components/Layout/Main";
 import LoadingText from "../../../../components/Utils/LoadingText";
 import useServiceQuery from "../../../../hooks/queries/useServiceQuery";
 import { routes } from "../../../../router/router";
+import { isOfferingUnavailable } from "../../../../utils";
 import PrivateServiceExplanation from "./PrivateServiceExplanation";
 import ServiceViewContent from "./ServiceViewContent";
 
@@ -50,6 +51,17 @@ const ServiceView: FC<ServiceViewProps> = ({ datastoreId, offeringId, datasheetN
                         )}
                     </div>
 
+                    {isOfferingUnavailable(serviceQuery.data.status) && (
+                        <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-mb-4w")}>
+                            <Alert
+                                severity="info"
+                                closable={false}
+                                title={serviceQuery.data.status === OfferingStatusEnum.UNPUBLISHED ? "Service dépublié" : "Service en cours de dépublication"}
+                                description={"Ce service n’est plus diffusé. Vous pouvez uniquement terminer sa dépublication depuis la fiche de donnée."}
+                            />
+                        </div>
+                    )}
+
                     {serviceQuery.data?.status === OfferingStatusEnum.UNSTABLE && (
                         <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-mb-4w")}>
                             <Alert
@@ -77,7 +89,7 @@ const ServiceView: FC<ServiceViewProps> = ({ datastoreId, offeringId, datasheetN
                         </div>
                     )}
 
-                    {serviceQuery.data?.open === true ? (
+                    {isOfferingUnavailable(serviceQuery.data.status) ? null : serviceQuery.data?.open === true ? (
                         <ServiceViewContent datastoreId={datastoreId} offeringId={offeringId} datasheetName={datasheetName} />
                     ) : (
                         <div className={fr.cx("fr-grid-row", "fr-mb-4w")}>

--- a/assets/utils/offering.ts
+++ b/assets/utils/offering.ts
@@ -1,4 +1,12 @@
-import { OfferingTypeEnum } from "@/@types/app";
+import { OfferingStatusEnum, OfferingTypeEnum } from "@/@types/app";
+import { OfferingStandardListResponseDtoStatusEnum } from "@/@types/entrepot";
+
+/**
+ * Indique si l'offering n'est plus diffusée (dépubliée ou en cours de dépublication) :
+ * l'API Entrepôt refuse alors la plupart des opérations (édition, styles, permissions...).
+ */
+export const isOfferingUnavailable = (status: OfferingStatusEnum | OfferingStandardListResponseDtoStatusEnum): boolean =>
+    [OfferingStatusEnum.UNPUBLISHING, OfferingStatusEnum.UNPUBLISHED].includes(status as OfferingStatusEnum);
 
 export const offeringTypeDisplayName = (type: OfferingTypeEnum): string => {
     switch (type) {

--- a/src/Constants/EntrepotApi/OfferingStatuses.php
+++ b/src/Constants/EntrepotApi/OfferingStatuses.php
@@ -8,5 +8,6 @@ final class OfferingStatuses
     public const MODIFYING = 'MODIFYING';
     public const PUBLISHED = 'PUBLISHED';
     public const UNPUBLISHING = 'UNPUBLISHING';
+    public const UNPUBLISHED = 'UNPUBLISHED';
     public const UNSTABLE = 'UNSTABLE';
 }

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -8,6 +8,7 @@ use App\Constants\EntrepotApi\CommonTags;
 use App\Constants\EntrepotApi\ConfigurationMetadataTypes;
 use App\Constants\EntrepotApi\ConfigurationStatuses;
 use App\Constants\EntrepotApi\ConfigurationTypes;
+use App\Constants\EntrepotApi\OfferingStatuses;
 use App\Constants\EntrepotApi\OfferingTypes;
 use App\Constants\EntrepotApi\PermissionTypes;
 use App\Constants\EntrepotApi\StoredDataTypes;
@@ -15,6 +16,7 @@ use App\Dto\Datasheet\DatasheetServices;
 use App\Dto\Services\CommonDTO;
 use App\Entity\CswMetadata\CswMetadata;
 use App\Entity\CswMetadata\CswMetadataLayer;
+use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\CapabilitiesService;
 use App\Services\GeonetworkApiService;
@@ -87,7 +89,7 @@ class CartesServiceApiService
 
             // TMS
             if (StoredDataTypes::ROK4_PYRAMID_VECTOR === $storedData['type']) {
-                // Metadatas (TMS)
+                // Metadata (TMS)
                 $urls = array_values(array_filter($offering['urls'], static function ($url) {
                     return 'TMS' == $url['type'];
                 }));
@@ -255,42 +257,144 @@ class CartesServiceApiService
      */
     private function unpublishOfferingAndConfiguration(string $datastoreId, array $offering, bool $removeStyleFiles = true): array
     {
-        // suppression de l'offering
-        $this->configurationApiService->removeOffering($datastoreId, $offering['_id'])->await();
-        $configurationId = $offering['configuration']['_id'];
-        $configuration = null;
+        $this->removeOfferingFully($datastoreId, $offering);
 
-        // suppression de la configuration
-        // la suppression de l'offering nécessite quelques instants, et tant que la suppression de l'offering n'est pas faite, on ne peut pas demander la suppression de la configuration
-        for ($attempt = 1; $attempt <= self::UNPUBLISH_MAX_ATTEMPTS; ++$attempt) {
-            $configuration = $this->configurationApiService->get($datastoreId, $configurationId)->array();
-            if (ConfigurationStatuses::UNPUBLISHED === $configuration['status']) {
-                break;
-            }
-            if ($attempt < self::UNPUBLISH_MAX_ATTEMPTS) {
-                sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
-            }
-        }
+        $configuration = $this->waitForConfigurationUnpublished($datastoreId, $offering['configuration']['_id']);
 
-        if (ConfigurationStatuses::UNPUBLISHED !== $configuration['status']) {
-            $timeoutSeconds = self::UNPUBLISH_MAX_ATTEMPTS * self::UNPUBLISH_RETRY_DELAY_SECONDS;
-            $this->logger->warning('{class}: Timeout waiting for offering {offeringId} unpublish before removing configuration {configurationId}', [
-                'class' => self::class,
-                'offeringId' => $offering['_id'],
-                'configurationId' => $configurationId,
-                'timeout' => $timeoutSeconds,
-            ]);
-
-            throw new CartesApiException('La suppression du service prend trop de temps, veuillez réessayer', Response::HTTP_REQUEST_TIMEOUT, ['offering_id' => $offering['_id'], 'configuration_id' => $configurationId, 'timeout' => $timeoutSeconds]);
-        }
-
-        $this->configurationApiService->remove($datastoreId, $configurationId)->await();
+        $this->configurationApiService->remove($datastoreId, $configuration['_id'])->await();
 
         if (true === $removeStyleFiles) {
             $this->removeStyleFiles($datastoreId, $configuration);
         }
 
         return $configuration;
+    }
+
+    /**
+     * Supprime complètement une offering : dépublication (1er DELETE) puis suppression définitive (2e DELETE sur l'offering UNPUBLISHED, qui supprime aussi ses accès et permissions).
+     *
+     * @param array<mixed> $offering
+     */
+    private function removeOfferingFully(string $datastoreId, array $offering): void
+    {
+        // 1er DELETE : déclenche la dépublication, sauf reprise d'une tentative précédente déjà en cours ou terminée
+        if (!in_array($offering['status'] ?? null, [OfferingStatuses::UNPUBLISHING, OfferingStatuses::UNPUBLISHED], true)) {
+            $this->configurationApiService->removeOffering($datastoreId, $offering['_id'])->await();
+        }
+
+        $this->waitForOfferingUnpublished($datastoreId, $offering['_id']);
+
+        // 2e DELETE : suppression définitive
+        $this->configurationApiService->removeOffering($datastoreId, $offering['_id'])->await();
+
+        $this->waitForOfferingRemoved($datastoreId, $offering['_id']);
+    }
+
+    /**
+     * Attend que l'offering soit dépubliée (statut UNPUBLISHED).
+     *
+     * @return array<mixed> l'offering
+     *
+     * @throws CartesApiException avec le statut 408 si le délai d'attente est dépassé
+     */
+    public function waitForOfferingUnpublished(string $datastoreId, string $offeringId): array
+    {
+        $offering = null;
+        for ($attempt = 1; $attempt <= self::UNPUBLISH_MAX_ATTEMPTS; ++$attempt) {
+            $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
+            if (OfferingStatuses::UNPUBLISHED === $offering['status']) {
+                return $offering;
+            }
+
+            // statut terminal : la dépublication a échoué, inutile d'attendre davantage
+            if (OfferingStatuses::UNSTABLE === $offering['status']) {
+                $this->logger->warning('{class}: Offering {offeringId} became UNSTABLE while waiting for its unpublication', [
+                    'class' => self::class,
+                    'offeringId' => $offeringId,
+                ]);
+
+                throw new CartesApiException('La dépublication du service a échoué', Response::HTTP_INTERNAL_SERVER_ERROR, ['offering_id' => $offeringId, 'status' => $offering['status']]);
+            }
+
+            if ($attempt < self::UNPUBLISH_MAX_ATTEMPTS) {
+                sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
+            }
+        }
+
+        $timeoutSeconds = self::UNPUBLISH_MAX_ATTEMPTS * self::UNPUBLISH_RETRY_DELAY_SECONDS;
+        $this->logger->warning('{class}: Timeout waiting for offering {offeringId} to reach UNPUBLISHED status (last status: {status})', [
+            'class' => self::class,
+            'offeringId' => $offeringId,
+            'status' => $offering['status'],
+            'timeout' => $timeoutSeconds,
+        ]);
+
+        throw new CartesApiException('La dépublication du service prend trop de temps, veuillez réessayer', Response::HTTP_REQUEST_TIMEOUT, ['offering_id' => $offeringId, 'status' => $offering['status'], 'timeout' => $timeoutSeconds]);
+    }
+
+    /**
+     * Attend que l'offering soit effectivement supprimée (GET renvoie 404) après le 2e DELETE.
+     *
+     * @throws CartesApiException avec le statut 408 si le délai d'attente est dépassé
+     */
+    private function waitForOfferingRemoved(string $datastoreId, string $offeringId): void
+    {
+        for ($attempt = 1; $attempt <= self::UNPUBLISH_MAX_ATTEMPTS; ++$attempt) {
+            try {
+                $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
+            } catch (ApiException $e) {
+                if (Response::HTTP_NOT_FOUND === $e->getStatusCode()) {
+                    return;
+                }
+
+                throw $e;
+            }
+
+            if ($attempt < self::UNPUBLISH_MAX_ATTEMPTS) {
+                sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
+            }
+        }
+
+        $timeoutSeconds = self::UNPUBLISH_MAX_ATTEMPTS * self::UNPUBLISH_RETRY_DELAY_SECONDS;
+        $this->logger->warning('{class}: Timeout waiting for offering {offeringId} to be actually removed after the 2nd DELETE', [
+            'class' => self::class,
+            'offeringId' => $offeringId,
+            'timeout' => $timeoutSeconds,
+        ]);
+
+        throw new CartesApiException('La suppression du service prend trop de temps, veuillez réessayer', Response::HTTP_REQUEST_TIMEOUT, ['offering_id' => $offeringId, 'timeout' => $timeoutSeconds]);
+    }
+
+    /**
+     * Attend que la configuration soit dépubliée (statut UNPUBLISHED), condition pour pouvoir la supprimer.
+     *
+     * @return array<mixed> la configuration
+     *
+     * @throws CartesApiException avec le statut 408 si le délai d'attente est dépassé
+     */
+    public function waitForConfigurationUnpublished(string $datastoreId, string $configurationId): array
+    {
+        $configuration = null;
+        for ($attempt = 1; $attempt <= self::UNPUBLISH_MAX_ATTEMPTS; ++$attempt) {
+            $configuration = $this->configurationApiService->get($datastoreId, $configurationId)->array();
+            if (ConfigurationStatuses::UNPUBLISHED === $configuration['status']) {
+                return $configuration;
+            }
+
+            if ($attempt < self::UNPUBLISH_MAX_ATTEMPTS) {
+                sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
+            }
+        }
+
+        $timeoutSeconds = self::UNPUBLISH_MAX_ATTEMPTS * self::UNPUBLISH_RETRY_DELAY_SECONDS;
+        $this->logger->warning('{class}: Timeout waiting for configuration {configurationId} to reach UNPUBLISHED status before removal', [
+            'class' => self::class,
+            'configurationId' => $configurationId,
+            'status' => $configuration['status'],
+            'timeout' => $timeoutSeconds,
+        ]);
+
+        throw new CartesApiException('La suppression du service prend trop de temps, veuillez réessayer', Response::HTTP_REQUEST_TIMEOUT, ['configuration_id' => $configurationId, 'status' => $configuration['status'], 'timeout' => $timeoutSeconds]);
     }
 
     /**
@@ -362,7 +466,7 @@ class CartesServiceApiService
 
             // On recrée l'offering si changement d'endpoint, sinon demande la synchronisation
             if ($oldOffering['open'] !== $endpoint['open']) {
-                $this->configurationApiService->removeOffering($datastoreId, $oldOffering['_id'])->await();
+                $this->removeOfferingFully($datastoreId, $oldOffering);
 
                 $offering = $this->configurationApiService->addOffering($datastoreId, $oldConfiguration['_id'], $endpoint['_id'], $endpoint['open'])->array();
             } else {


### PR DESCRIPTION
Ajustement au changement de l'API entrepôt, 2 fois DELETE de l'offering avant DELETE sur configurationg : https://geoplateforme.github.io/tutoriels/production/changements/2026/08/19/ajout-du-statut-unpublished-pour-les-offres--correction-de-bugs-de-lentrep%C3%B4t/