### PR TITLE
feat(ci): cycle de vie des images GHCR (publication PR + nettoyage périodique)

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -7,12 +7,19 @@ on:
         tags: ["v*"]
     pull_request:
 
+# Annule les runs obsolètes d'une même PR (jamais ceux de main ou d'un tag)
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
     # Use docker.io for Docker Hub if empty
     REGISTRY: ghcr.io
     # github.repository as <account>/<repo>
     IMAGE_NAME: ${{ github.repository }}
-    IS_TAG: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    # Push sur GHCR : tag de release, ou PR interne hors bots (Dependabot : token en lecture seule ;
+    # Renovate : images sans intérêt). Push sur main, PR de fork ou de bot : build + scan uniquement.
+    PUSH_IMAGE: ${{ github.ref_type == 'tag' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/')) }}
 
 jobs:
     docker-build-publish-scan:
@@ -36,10 +43,10 @@ jobs:
             - name: Setup Docker buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-            # Login nécessaire uniquement quand on pousse (tag semver)
+            # Login nécessaire uniquement quand on pousse
             # https://github.com/docker/login-action
             - name: Log into registry ${{ env.REGISTRY }}
-              if: env.IS_TAG == 'true'
+              if: env.PUSH_IMAGE == 'true'
               uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
               with:
                   registry: ${{ env.REGISTRY }}
@@ -55,40 +62,41 @@ jobs:
                   DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                  # Éphémère : pr-<numéro>-<sha court> (le numéro de PR est parsé par le sweep de nettoyage).
+                  # Durable : X.Y.Z, X.Y et latest (flavor auto) sur tag de release uniquement.
                   tags: |
-                      type=ref,event=branch
-                      type=ref,event=pr
-                      type=sha
+                      type=ref,event=pr,suffix=-{{sha}}
                       type=semver,pattern={{version}}
                       type=semver,pattern={{major}}.{{minor}}
 
-            # Build unique : push (avec SBOM + provenance) sur tag semver, sinon load local pour le scan
+            # Build unique : push si PUSH_IMAGE, sinon load local pour le scan.
+            # SBOM + provenance réservés aux releases pour garder les images de PR légères.
             # https://github.com/docker/build-push-action
-            - name: Build Docker image (push to registry on semver tag only)
+            - name: Build Docker image (push to registry per PUSH_IMAGE)
               id: build
               uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
               with:
                   context: .
                   file: .docker/Dockerfile
                   pull: true
-                  push: ${{ env.IS_TAG == 'true' }}
-                  load: ${{ env.IS_TAG != 'true' }}
-                  sbom: ${{ env.IS_TAG == 'true' }}
-                  provenance: ${{ env.IS_TAG == 'true' && 'mode=max' || 'false' }}
+                  push: ${{ env.PUSH_IMAGE == 'true' }}
+                  load: ${{ env.PUSH_IMAGE != 'true' }}
+                  sbom: ${{ github.ref_type == 'tag' }}
+                  provenance: ${{ github.ref_type == 'tag' && 'mode=max' || 'false' }}
                   target: prod
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   # annotations uniquement quand on pousse : l'exporter docker (load) ne les supporte pas
-                  annotations: ${{ env.IS_TAG == 'true' && steps.meta.outputs.annotations || '' }}
+                  annotations: ${{ env.PUSH_IMAGE == 'true' && steps.meta.outputs.annotations || '' }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 
-            # Scan informatif (ne bloque pas la CI en cas d'alertes levées). Sur tag : scan de l'image poussée par digest (même artefact);
+            # Scan informatif (ne bloque pas la CI en cas d'alertes levées). Si l'image est poussée : scan par digest (même artefact);
             # sinon : scan local par image ID (insensible aux tags multiples).
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
               with:
-                  image-ref: ${{ env.IS_TAG == 'true' && format('{0}/{1}@{2}', env.REGISTRY, env.IMAGE_NAME, steps.build.outputs.digest) || steps.build.outputs.imageid }}
+                  image-ref: ${{ env.PUSH_IMAGE == 'true' && format('{0}/{1}@{2}', env.REGISTRY, env.IMAGE_NAME, steps.build.outputs.digest) || steps.build.outputs.imageid }}
                   format: "sarif"
                   output: "trivy-results.sarif"
 
@@ -110,7 +118,7 @@ jobs:
                   # Lien Security filtré sur la ref exacte du run (PR, tag ou branche)
                   if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
                       filter="pr:${PR_NUMBER}"
-                  elif [ "$IS_TAG" = "true" ]; then
+                  elif [ "$GITHUB_REF_TYPE" = "tag" ]; then
                       filter="ref:refs/tags/${GITHUB_REF_NAME}"
                   else
                       filter="branch:${GITHUB_REF_NAME}"
@@ -123,7 +131,7 @@ jobs:
                       echo "|---|---|"
                       echo "| Image ID | \`${IMAGE_ID:-—}\` |"
                       echo "| Digest | \`${IMAGE_DIGEST:-—}\` |"
-                      echo "| Poussée sur ${REGISTRY} | $([ "$IS_TAG" = "true" ] && echo "oui" || echo "non (branche/PR)") |"
+                      echo "| Poussée sur ${REGISTRY} | $([ "$PUSH_IMAGE" = "true" ] && echo "oui" || echo "non (build de scan uniquement)") |"
                       if [ -f trivy-results.sarif ]; then
                           count=$(jq '[.runs[].results[]] | length' trivy-results.sarif)
                           echo "| Vulnérabilités (Trivy) | ${count} — [Security → Code scanning](https://github.com/${GITHUB_REPOSITORY}/security/code-scanning?query=${query}) |"

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -7,9 +7,9 @@ on:
         tags: ["v*"]
     pull_request:
 
-# Annule les runs obsolètes d'une même PR (jamais ceux de main ou d'un tag)
+# Annule les runs obsolètes d'une même PR ; groupe unique hors PR pour ne jamais remplacer un run de main ou de tag, même en attente
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -59,7 +59,8 @@ jobs:
               id: meta
               uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
               env:
-                  DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+                  # index seulement sur release : un push de PR (sans provenance/SBOM) n'a pas d'index OCI
+                  DOCKER_METADATA_ANNOTATIONS_LEVELS: ${{ github.ref_type == 'tag' && 'manifest,index' || 'manifest' }}
               with:
                   images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
                   # Éphémère : pr-<numéro>-<sha court> (le numéro de PR est parsé par le sweep de nettoyage).

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -14,6 +14,10 @@ on:
                 type: boolean
                 default: true
 
+# Sérialise les exécutions (cron et déclenchements manuels) : jamais deux suppressions en parallèle
+concurrency:
+    group: ghcr-cleanup
+
 permissions:
     contents: read
     packages: write
@@ -36,6 +40,10 @@ jobs:
                   script: |
                       const { owner, repo } = context.repo;
                       const graceDays = Number(process.env.GRACE_DAYS);
+                      if (!Number.isFinite(graceDays) || graceDays < 0) {
+                          core.setFailed(`GHCR_CLEANUP_GRACE_DAYS invalide : « ${process.env.GRACE_DAYS} »`);
+                          return;
+                      }
                       const cutoff = Date.now() - graceDays * 24 * 60 * 60 * 1000;
 
                       // (a) une seule énumération du registre, extraction des tags éphémères
@@ -112,8 +120,9 @@ jobs:
                           .write();
 
                       core.info(`${deletable.length} tag(s) supprimable(s)`);
-                      // regex ancrées : nos tags ne contiennent aucun métacaractère
-                      core.setOutput("delete-tags", deletable.map((tag) => `^${tag}$`).join(","));
+                      // une seule regex en alternance (en mode regex l'action ne découpe pas la liste) ;
+                      // ancrée, et nos tags ne contiennent aucun métacaractère
+                      core.setOutput("delete-tags", deletable.length ? `^(${deletable.join("|")})$` : "");
 
             # Action manifest-aware : supprime aussi les manifests enfants (plateformes) et les
             # référents attestation/cosign non taggés du parent supprimé, sans orphaniser les images conservées

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,130 @@
+name: Nettoyage des images GHCR éphémères
+
+# Supprime les images pr-<numéro>-<sha> dont la PR est fermée depuis au moins GRACE_DAYS jours.
+# Sans état ni mémoire entre les runs : chaque passage redérive tout du registre + de l'état des PR.
+# Fail-closed : toute PR irrésoluble (tag non parsable, erreur API, PR introuvable) protège ses images.
+on:
+    schedule:
+        - cron: "17 3 * * *"
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                description: "Lister sans supprimer"
+                type: boolean
+                default: true
+
+permissions:
+    contents: read
+    packages: write
+    pull-requests: read
+
+env:
+    # Dry-run par défaut : en manuel via l'input, en planifié tant que la variable de repo
+    # GHCR_CLEANUP_DRY_RUN ne vaut pas explicitement "false"
+    DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || github.event_name == 'schedule' && vars.GHCR_CLEANUP_DRY_RUN != 'false' }}
+    GRACE_DAYS: ${{ vars.GHCR_CLEANUP_GRACE_DAYS || 7 }}
+
+jobs:
+    cleanup:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Déterminer les tags supprimables
+              id: verdicts
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+              with:
+                  script: |
+                      const { owner, repo } = context.repo;
+                      const graceDays = Number(process.env.GRACE_DAYS);
+                      const cutoff = Date.now() - graceDays * 24 * 60 * 60 * 1000;
+
+                      // (a) une seule énumération du registre, extraction des tags éphémères
+                      const versions = await github.paginate(
+                          github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg,
+                          { org: owner, package_type: "container", package_name: repo.toLowerCase(), state: "active", per_page: 100 }
+                      );
+                      const images = [];
+                      for (const version of versions) {
+                          for (const tag of version.metadata?.container?.tags ?? []) {
+                              const match = tag.match(/^pr-(\d+)-[0-9a-f]+$/);
+                              if (match) {
+                                  images.push({ tag, pr: Number(match[1]) });
+                              } else if (tag.startsWith("pr-")) {
+                                  core.warning(`Tag éphémère non parsable, image protégée : ${tag}`);
+                              }
+                          }
+                      }
+                      core.info(`${versions.length} versions dans le registre, ${images.length} tags éphémères pr-*`);
+
+                      // (b) état des PR en une passe GraphQL par lots (alias), pas d'appel par image
+                      const prStates = new Map();
+                      const prNumbers = [...new Set(images.map((image) => image.pr))];
+                      for (let i = 0; i < prNumbers.length; i += 50) {
+                          const chunk = prNumbers.slice(i, i + 50);
+                          const fields = chunk.map((n) => `pr${n}: pullRequest(number: ${n}) { state closedAt }`).join(" ");
+                          let data;
+                          try {
+                              data = await github.graphql(
+                                  `query ($owner: String!, $repo: String!) { repository(owner: $owner, name: $repo) { ${fields} } }`,
+                                  { owner, repo }
+                              );
+                          } catch (error) {
+                              // réponse partielle (ex. PR introuvable) : on garde ce qui a été résolu
+                              data = error.data;
+                              if (!data?.repository) {
+                                  core.warning(`Erreur GraphQL, lot de PR protégé (${chunk.join(", ")}) : ${error.message}`);
+                                  continue;
+                              }
+                          }
+                          for (const n of chunk) {
+                              const pr = data.repository[`pr${n}`];
+                              if (pr) prStates.set(n, pr);
+                              else core.warning(`PR #${n} introuvable, ses images sont protégées`);
+                          }
+                      }
+
+                      // (c) verdict par image : supprimable ssi PR fermée depuis plus de GRACE_DAYS jours
+                      const deletable = [];
+                      const rows = [];
+                      for (const { tag, pr } of images.sort((a, b) => a.pr - b.pr || a.tag.localeCompare(b.tag))) {
+                          const state = prStates.get(pr);
+                          let verdict;
+                          if (!state) {
+                              verdict = "PROTÉGÉE (PR irrésolue)";
+                          } else if (state.state === "OPEN") {
+                              verdict = "CONSERVÉE (PR ouverte)";
+                          } else if (Date.parse(state.closedAt) <= cutoff) {
+                              verdict = "SUPPRIMABLE";
+                              deletable.push(tag);
+                          } else {
+                              verdict = `CONSERVÉE (délai de grâce ${graceDays} j)`;
+                          }
+                          rows.push([tag, `#${pr}`, state?.state ?? "?", state?.closedAt ?? "-", verdict]);
+                          core.info(rows.at(-1).join(" | "));
+                      }
+
+                      await core.summary
+                          .addHeading(`Nettoyage GHCR (dry-run : ${process.env.DRY_RUN}, grâce : ${graceDays} j)`, 3)
+                          .addTable([
+                              [{ data: "Tag", header: true }, { data: "PR", header: true }, { data: "État", header: true }, { data: "Fermée le", header: true }, { data: "Verdict", header: true }],
+                              ...rows,
+                          ])
+                          .write();
+
+                      core.info(`${deletable.length} tag(s) supprimable(s)`);
+                      // regex ancrées : nos tags ne contiennent aucun métacaractère
+                      core.setOutput("delete-tags", deletable.map((tag) => `^${tag}$`).join(","));
+
+            # Action manifest-aware : supprime aussi les manifests enfants (plateformes) et les
+            # référents attestation/cosign non taggés du parent supprimé, sans orphaniser les images conservées
+            - name: Supprimer les images
+              if: steps.verdicts.outputs.delete-tags != ''
+              uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  delete-tags: ${{ steps.verdicts.outputs.delete-tags }}
+                  # ceinture-bretelles : les tags de release sont exclus quoi qu'il arrive
+                  exclude-tags: ^(latest|sha-.+|\d+\.\d+(\.\d+)?)$
+                  use-regex: true
+                  dry-run: ${{ env.DRY_RUN }}
+                  validate: true
+                  log-level: info

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,6 +1,7 @@
 name: Nettoyage des images GHCR éphémères
 
-# Supprime les images pr-<numéro>-<sha> dont la PR est fermée depuis au moins GRACE_DAYS jours.
+# Supprime les images pr-<numéro>-<sha> (et pr-<numéro>, format historique) dont la PR est fermée
+# depuis au moins GRACE_DAYS jours.
 # Sans état ni mémoire entre les runs : chaque passage redérive tout du registre + de l'état des PR.
 # Fail-closed : toute PR irrésoluble (tag non parsable, erreur API, PR introuvable) protège ses images.
 on:
@@ -45,7 +46,7 @@ jobs:
                       const images = [];
                       for (const version of versions) {
                           for (const tag of version.metadata?.container?.tags ?? []) {
-                              const match = tag.match(/^pr-(\d+)-[0-9a-f]+$/);
+                              const match = tag.match(/^pr-(\d+)(?:-[0-9a-f]+)?$/);
                               if (match) {
                                   images.push({ tag, pr: Number(match[1]) });
                               } else if (tag.startsWith("pr-")) {
@@ -122,8 +123,9 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   delete-tags: ${{ steps.verdicts.outputs.delete-tags }}
-                  # ceinture-bretelles : les tags de release sont exclus quoi qu'il arrive
-                  exclude-tags: ^(latest|sha-.+|\d+\.\d+(\.\d+)?)$
+                  # ceinture-bretelles : les tags de release sont exclus quoi qu'il arrive,
+                  # y compris les formats historiques (vX.Y.Z, v0.5.5.1, rc/beta)
+                  exclude-tags: ^(latest|sha-.+|v?\d+(\.\d+){1,3}(-[0-9A-Za-z.]+)?)$
                   use-regex: true
                   dry-run: ${{ env.DRY_RUN }}
                   validate: true


### PR DESCRIPTION
## Changements

- Les PR internes publient désormais une image éphémère `pr-<numéro>-<sha court>` sur GHCR (PR de forks, Dependabot et Renovate exclues : build + scan uniquement, comme avant)
- Plus aucune image poussée sur les commits de `main` ni de tag `sha-*` sur les releases : les images durables sont uniquement `X.Y.Z`, `X.Y` et `latest` (et, comme avant, les préversions `X.Y.Z-beta.N`), créées par les tags `v*`
- Nouveau workflow nocturne de nettoyage : supprime les images éphémères dont la PR est fermée depuis au moins `GHCR_CLEANUP_GRACE_DAYS` jours (défaut 7), sans jamais toucher les tags de release ni les images de PR ouvertes ; fail-closed au moindre doute (tag non parsable, erreur API, PR introuvable) ; suppression manifest-aware (enfants plateforme et référents attestation/cosign) via dataaxiom/ghcr-cleanup-action
- Annulation des runs de build obsolètes d'une même PR (bloc `concurrency`)

## Validation

- `actionlint` passe sur les deux workflows
- Le nettoyage reste en dry-run tant que la variable de repo `GHCR_CLEANUP_DRY_RUN` ne vaut pas `false` : basculer seulement après revue du tableau de verdicts d'un run manuel
- Après merge : vérifier qu'une PR de test pousse bien `pr-<n>-<sha>` et qu'un commit sur `main` ne pousse rien

Changement de comportement délibéré : jusqu'ici seules les releases étaient poussées sur GHCR ; les images de PR internes sont désormais publiées, et les releases ne portent plus de tag `sha-*`.
