### PR TITLE
fix(ci): nettoyage GHCR, liste de tags exacts au lieu de regex

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -120,9 +120,8 @@ jobs:
                           .write();
 
                       core.info(`${deletable.length} tag(s) supprimable(s)`);
-                      // une seule regex en alternance (en mode regex l'action ne découpe pas la liste) ;
-                      // ancrée, et nos tags ne contiennent aucun métacaractère
-                      core.setOutput("delete-tags", deletable.length ? `^(${deletable.join("|")})$` : "");
+                      // tags exacts, sans métacaractère wildcard : l'action les matche littéralement
+                      core.setOutput("delete-tags", deletable.join(","));
 
             # Action manifest-aware : supprime aussi les manifests enfants (plateformes) et les
             # référents attestation/cosign non taggés du parent supprimé, sans orphaniser les images conservées
@@ -132,10 +131,9 @@ jobs:
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   delete-tags: ${{ steps.verdicts.outputs.delete-tags }}
-                  # ceinture-bretelles : les tags de release sont exclus quoi qu'il arrive,
-                  # y compris les formats historiques (vX.Y.Z, v0.5.5.1, rc/beta)
-                  exclude-tags: ^(latest|sha-.+|v?\d+(\.\d+){1,3}(-[0-9A-Za-z.]+)?)$
-                  use-regex: true
+                  # ceinture-bretelles : tout tag commençant par un chiffre ou « v » (toutes les familles
+                  # de release, formats historiques compris) est exclu ; les tags éphémères commencent par « pr- »
+                  exclude-tags: latest,sha-*,v*,0*,1*,2*,3*,4*,5*,6*,7*,8*,9*
                   dry-run: ${{ env.DRY_RUN }}
                   validate: true
                   log-level: info


### PR DESCRIPTION
Le premier run du sweep échoue : en mode regex, ghcr-cleanup-action valide les patterns avec safe-regex2, qui rejette notre `exclude-tags` (quantificateurs imbriqués). Le mode regex plafonne aussi les patterns à 1000 caractères, ce qui aurait cassé `delete-tags` au-delà d'environ 55 tags supprimables dans un même run.

## Changements

- `delete-tags` : liste de tags exacts séparés par des virgules (match littéral, pas de plafond)
- `exclude-tags` : globs `latest,sha-*,v*,0*` à `9*` - tout tag commençant par un chiffre ou « v » est protégé, les tags éphémères commencent par « pr- »
- suppression de `use-regex`

## Validation

- `actionlint` passe
- Après merge : run manuel en dry-run ; attendu : `pr-709` SUPPRIMABLE, `pr-1144-*` CONSERVÉES (délai de grâce), aucun tag de release listé, step de suppression sans erreur de validation