### PR TITLE
feat(logs): logs lisibles et corrélés dans Grafana/Loki

### DIFF
--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -15,11 +15,13 @@
 	# Conteneur immutable : pas de reload de config, l'endpoint d'admin est inutile
 	admin off
 
-	# client_ip des access logs = IP réelle résolue depuis X-Forwarded-For.
+	# client_ip des access logs = première IP non privée de X-Forwarded-For en
+	# partant de la droite (strict) : un header forgé par le client est sans effet.
 	# N'affecte pas PHP : REMOTE_ADDR reste le pair TCP, la résolution applicative
 	# appartient à Symfony (TRUSTED_PROXIES).
 	servers {
 		trusted_proxies static private_ranges
+		trusted_proxies_strict
 	}
 
 	# Logs en texte brut ; level_format upper évite les codes couleur ANSI

--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -15,6 +15,13 @@
 	# Conteneur immutable : pas de reload de config, l'endpoint d'admin est inutile
 	admin off
 
+	# client_ip des access logs = IP réelle résolue depuis X-Forwarded-For.
+	# N'affecte pas PHP : REMOTE_ADDR reste le pair TCP, la résolution applicative
+	# appartient à Symfony (TRUSTED_PROXIES).
+	servers {
+		trusted_proxies static private_ranges
+	}
+
 	# Logs en texte brut ; level_format upper évite les codes couleur ANSI
 	log {
 		format console {
@@ -27,8 +34,6 @@
 
 	# respond (405 TRACE, 404 .ht*) doit passer avant les redirections
 	order respond before redir
-
-	# La résolution X-Forwarded-For appartient à Symfony (TRUSTED_PROXIES)
 }
 
 :8000 {
@@ -66,7 +71,9 @@
 	@hidden path */.ht*
 	rewrite @hidden /__fichier-cache__
 
-	# Redirections héritées (ex-RedirectMatch du vhost Apache), query string préservée
+	# Redirections héritées (ex-RedirectMatch du vhost Apache), query string préservée.
+	# Tout ajout ici doit aussi être exclu du matcher @phpHandled ci-dessous,
+	# sinon la redirection ne sera pas loggée.
 	redir / /explorer-les-cartes{?query} 301
 	@faq path /faq /faq/
 	redir @faq /aide/fr{?query} 301
@@ -81,23 +88,38 @@
 	@indexphp path_regexp idx ^/index\.php(?:/(.*))?$
 	redir @indexphp /{re.idx.1}{?query} 301
 
-	# Ne pas logger les probes de santé (équivalent du SetEnvIf dontlog)
+	# Ne pas logger les probes de santé : redondant tant que @phpHandled est actif,
+	# gardé comme filet si le log_skip ci-dessous est retiré (rollback)
 	@health path_regexp ^/tableau-de-bord/health/?$
 	log_skip @health
 
+	# Requêtes dynamiques (front controller) : loggées par Symfony en logfmt
+	# (voir docs/developer/logs.md), Caddy ne logge que ce qu'il sert lui-même
+	# (fichiers existants, redirections héritées ci-dessus, canonicalisation, TRACE)
+	@phpHandled {
+		not file
+		not path / /faq /faq/ /a-propos /a-propos/ /nous-ecrire /nous-ecrire/ /offre /offre/ /index.php*
+		not method TRACE
+	}
+	log_skip @phpHandled
+
 	# Access log en texte brut ; filter supprime les champs et headers sans intérêt
 	# (blocklist : un nouveau header non listé réapparaîtra dans les logs).
-	# Conservés volontairement : Referer, User-Agent, X-Forwarded-For (parité avec
-	# l'ex-LogFormat Apache), X-Request-Id, host/method/uri/proto, status, size, duration.
+	# Conservés volontairement : Referer, User-Agent, X-Request-Id, client_ip
+	# (résolu via trusted_proxies), host/method/uri, status, size, duration (en ms).
 	log {
 		output stdout
 		format filter {
 			wrap console {
 				level_format upper
+				duration_format ms
 			}
 			fields {
-				# champs hors headers
+				# champs hors headers (client_ip suffit : remote_ip = ingress, XFF = redondant)
+				request>remote_ip delete
 				request>remote_port delete
+				request>proto delete
+				request>headers>X-Forwarded-For delete
 				bytes_read delete
 				user_id delete
 				resp_headers delete
@@ -126,7 +148,7 @@
 				request>headers>Sec-Ch-Ua-Platform delete
 				request>headers>Sec-Gpc delete
 				request>headers>Dnt delete
-				# ajoutés par l'ingress (redondants : XFF suffit)
+				# ajoutés par l'ingress (redondants : client_ip suffit)
 				request>headers>X-Real-Ip delete
 				request>headers>X-Scheme delete
 				request>headers>X-Forwarded-Proto delete

--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -103,6 +103,10 @@
 	}
 	log_skip @phpHandled
 
+	# Les .ht* finissent aussi dans le front controller (réécriture ci-dessus) mais
+	# public/.htaccess existe : @phpHandled ne les saute pas, Symfony les loggerait en double
+	log_skip @hidden
+
 	# Access log en texte brut ; filter supprime les champs et headers sans intérêt
 	# (blocklist : un nouveau header non listé réapparaîtra dans les logs).
 	# Conservés volontairement : Referer, User-Agent, X-Request-Id, client_ip

--- a/.docker/Caddyfile
+++ b/.docker/Caddyfile
@@ -100,7 +100,7 @@
 	# (fichiers existants, redirections héritées ci-dessus, canonicalisation, TRACE)
 	@phpHandled {
 		not file
-		not path / /faq /faq/ /a-propos /a-propos/ /nous-ecrire /nous-ecrire/ /offre /offre/ /index.php*
+		not path / /faq /faq/ /a-propos /a-propos/ /nous-ecrire /nous-ecrire/ /offre /offre/ /index.php /index.php/*
 		not method TRACE
 	}
 	log_skip @phpHandled

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - access # Ligne d'accès applicative, une par requête (voir docs/developer/logs.md)
 
 when@dev:
     monolog:
@@ -45,20 +46,27 @@ when@prod:
                 handler: stdout_stream
                 min_level: notice
                 max_level: warning
-                channels: ["!deprecation"]
+                channels: ["!deprecation", "!access"]
 
             # Écrit les logs opérationnels sur stdout pour Kubernetes.
             stdout_stream:
                 type: stream
                 path: php://stdout
-                channels: ["!deprecation"]
+                channels: ["!deprecation", "!access"]
 
             # Écrit les erreurs et niveaux supérieurs sur stderr.
             stderr_error_plus:
                 type: stream
                 path: php://stderr
                 level: error
-                channels: ["!deprecation"]
+                channels: ["!deprecation", "!access"]
+
+            # Ligne d'accès applicative : message logfmt brut sur stdout, sans décoration.
+            access:
+                type: stream
+                path: php://stdout
+                channels: [access]
+                formatter: app.monolog.access_line_formatter
 
             # Isole les deprécations sur stderr via leur canal dédié.
             deprecation:
@@ -70,4 +78,4 @@ when@prod:
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!access"]

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,5 +35,10 @@ services:
         class: App\ApiClient\ApiClient
         factory: ['@App\ApiClient\ApiClientFactory', "createEspaceCoStyleClient"]
 
+    # Formatter du canal access : message logfmt seul, la ligne doit rester brute pour Loki
+    app.monolog.access_line_formatter:
+        class: Monolog\Formatter\LineFormatter
+        arguments: ["%%message%%\n"]
+
 imports:
     - { resource: parameters.yaml }

--- a/docs/developer/logs.md
+++ b/docs/developer/logs.md
@@ -1,0 +1,34 @@
+# Logs applicatifs et corrélation
+
+Le dashboard Grafana/Loki de la plateforme affiche les lignes brutes (pas de parsing LogQL) et la recherche se fait par sous-chaîne. Le collecteur du cluster enveloppe chaque ligne dans un JSON qui échappe les guillemets : une ligne de log n'est donc lisible et cherchable que si ses informations sont des tokens plats sans guillemets.
+
+## Ligne d'accès applicative (canal monolog `access`)
+
+`AccessLogSubscriber` (kernel.terminate, donc après envoi de la réponse) émet une ligne logfmt par requête traitée par Symfony :
+
+```
+method=GET path=/api/datastores/190b.../metadata/arbres status=200 duration_ms=226 route=cartesgouvfr_api_metadata_get request_id=38aa3379... user=fc5a7948-...
+```
+
+- Chaque token se cherche tel quel dans le dashboard : `status=500`, un chemin, un request_id, un user.
+- `duration_ms` est mesuré depuis `REQUEST_TIME_FLOAT` (temps PHP).
+- `route` et `user` sont omis quand ils n'existent pas (404, requête anonyme).
+- En prod, le handler `access` sort le message brut sur stdout ; les autres handlers excluent le canal pour éviter la double sortie. Les requêtes servies par Caddy sans PHP (fichiers statiques, redirections héritées, TRACE) restent loggées par l'access log Caddy (voir `.docker/Caddyfile`), qui saute les requêtes dynamiques (`log_skip`).
+- Limite assumée : une requête qui tue le process PHP (fatal dur, OOM) n'a pas de ligne d'accès, seule la trace stderr subsiste.
+
+## Corrélation par request_id
+
+`RequestIdProcessor` ajoute `extra.request_id` à tous les enregistrements monolog : l'id vient du header `X-Request-Id` posé par l'ingress (aussi présent dans l'access log Caddy), ou est généré (UUID v7) hors ingress. Coller un request_id dans la recherche du dashboard remonte la ligne d'accès et tous les logs applicatifs de la requête.
+
+## Données personnelles
+
+Finalité : sécurité et diagnostic (traçabilité par compte attendue par les recommandations CNIL/ANSSI de journalisation). Minimisation appliquée :
+
+| Champ        | Contenu                                    | Minimisation                                                                                 |
+| ------------ | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `user`       | UUID technique du compte (`User::getId()`) | jamais l'email, le username ni le nom                                                        |
+| `path`       | URI brute                                  | sans query string (risque de données personnelles dans les paramètres)                       |
+| `request_id` | aléatoire par requête                      | ne relie pas l'activité entre requêtes                                                       |
+| adresse IP   | absente                                    | l'IP reste uniquement dans l'access log Caddy (statiques/redirections), comme historiquement |
+
+Ne jamais logger d'objet utilisateur, d'email ou de token dans le `context` d'un log applicatif.

--- a/docs/developer/logs.md
+++ b/docs/developer/logs.md
@@ -20,15 +20,17 @@ method=GET path=/api/datastores/190b.../metadata/arbres status=200 duration_ms=2
 
 `RequestIdProcessor` ajoute `extra.request_id` à tous les enregistrements monolog : l'id vient du header `X-Request-Id` posé par l'ingress (aussi présent dans l'access log Caddy), ou est généré (UUID v7) hors ingress. Coller un request_id dans la recherche du dashboard remonte la ligne d'accès et tous les logs applicatifs de la requête.
 
+La corrélation suppose que l'ingress écrase tout `X-Request-Id` fourni par le client (comportement standard des ingress nginx). L'application valide le format de l'id (anti-injection logfmt) mais ne peut pas garantir son unicité si cette hypothèse tombe : au pire, une recherche corrèle des requêtes sans lien, sans impact applicatif.
+
 ## Données personnelles
 
 Finalité : sécurité et diagnostic (traçabilité par compte attendue par les recommandations CNIL/ANSSI de journalisation). Minimisation appliquée :
 
-| Champ        | Contenu                                    | Minimisation                                                                                 |
-| ------------ | ------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| `user`       | UUID technique du compte (`User::getId()`) | jamais l'email, le username ni le nom                                                        |
-| `path`       | URI brute                                  | sans query string (risque de données personnelles dans les paramètres)                       |
-| `request_id` | aléatoire par requête                      | ne relie pas l'activité entre requêtes                                                       |
-| adresse IP   | absente                                    | l'IP reste uniquement dans l'access log Caddy (statiques/redirections), comme historiquement |
+| Champ        | Contenu                                       | Minimisation                                                                                 |
+| ------------ | --------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `user`       | UUID technique du compte (`User::getId()`)    | jamais l'email, le username ni le nom                                                        |
+| `path`       | URI brute                                     | sans query string (risque de données personnelles dans les paramètres)                       |
+| `request_id` | aléatoire par requête (ingress, sinon généré) | ne relie pas l'activité entre requêtes                                                       |
+| adresse IP   | absente                                       | l'IP reste uniquement dans l'access log Caddy (statiques/redirections), comme historiquement |
 
 Ne jamais logger d'objet utilisateur, d'email ou de token dans le `context` d'un log applicatif.

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -9,6 +9,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class AppController extends AbstractController
 {
+    public const HEALTH_ROUTE = 'cartesgouvfr_app_health';
+
     #[Route(
         '/{reactRouting}',
         name: 'cartesgouvfr_app',
@@ -29,7 +31,7 @@ class AppController extends AbstractController
 
     #[Route(
         '/tableau-de-bord/health',
-        name: 'cartesgouvfr_app_health',
+        name: self::HEALTH_ROUTE,
         options: ['expose' => true]
     )]
     public function health(): Response

--- a/src/Listener/AccessLogSubscriber.php
+++ b/src/Listener/AccessLogSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Listener;
+
+use App\Controller\AppController;
+use App\Monolog\RequestIdResolver;
+use App\Security\User;
+use Monolog\Attribute\WithMonologChannel;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Émet une ligne d'accès logfmt par requête, cherchable telle quelle dans Grafana/Loki.
+ *
+ * Voir docs/developer/logs.md pour le format et les choix de minimisation (RGPD).
+ */
+#[WithMonologChannel('access')]
+final class AccessLogSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private Security $security,
+        private RequestIdResolver $requestIdResolver,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // kernel.terminate : après envoi de la réponse, aucune latence ajoutée
+            KernelEvents::TERMINATE => 'onKernelTerminate',
+        ];
+    }
+
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        $request = $event->getRequest();
+        $route = $request->attributes->get('_route');
+
+        // Probes de santé exclues, comme dans l'access log Caddy
+        if (AppController::HEALTH_ROUTE === $route) {
+            return;
+        }
+        $user = $this->security->getUser();
+
+        $tokens = [
+            'method' => $request->getMethod(),
+            // URI brute sans query string : pas de données personnelles ni de caractères ambigus
+            'path' => strtok($request->getRequestUri(), '?'),
+            'status' => $event->getResponse()->getStatusCode(),
+            'duration_ms' => (int) round((microtime(true) - (float) $request->server->get('REQUEST_TIME_FLOAT')) * 1000),
+            'route' => \is_string($route) ? $route : null,
+            'request_id' => $this->requestIdResolver->resolve($request),
+            // UUID technique du compte, jamais l'email ni le username
+            'user' => $user instanceof User ? $user->getId() : null,
+        ];
+
+        $line = [];
+        foreach ($tokens as $key => $value) {
+            if (null !== $value) {
+                $line[] = sprintf('%s=%s', $key, $value);
+            }
+        }
+
+        $this->logger->info(implode(' ', $line));
+    }
+}

--- a/src/Monolog/RequestIdProcessor.php
+++ b/src/Monolog/RequestIdProcessor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Monolog;
+
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Ajoute le request_id à chaque enregistrement pour corréler tous les logs d'une même requête.
+ */
+class RequestIdProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private RequestStack $requestStack,
+        private RequestIdResolver $requestIdResolver,
+    ) {
+    }
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null !== $request) {
+            $record->extra['request_id'] = $this->requestIdResolver->resolve($request);
+        }
+
+        return $record;
+    }
+}

--- a/src/Monolog/RequestIdResolver.php
+++ b/src/Monolog/RequestIdResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Monolog;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Fournit l'identifiant de corrélation d'une requête : X-Request-Id posé par l'ingress, sinon généré.
+ */
+class RequestIdResolver
+{
+    private const REQUEST_ATTRIBUTE = '_request_id';
+
+    public function resolve(Request $request): string
+    {
+        $requestId = $request->attributes->get(self::REQUEST_ATTRIBUTE);
+        if (!\is_string($requestId)) {
+            // Header contrôlé par le client : format strict, sinon id généré (évite de forger des tokens logfmt)
+            $header = (string) $request->headers->get('X-Request-Id');
+            $requestId = preg_match('/^[A-Za-z0-9._-]{1,64}$/', $header) ? $header : (string) Uuid::v7();
+            $request->attributes->set(self::REQUEST_ATTRIBUTE, $requestId);
+        }
+
+        return $requestId;
+    }
+}


### PR DESCRIPTION
PR empilée sur feat/frankenphp-migration.

Le dashboard Grafana/Loki affiche les lignes brutes (pas de parsing LogQL, recherche par sous-chaîne) et le collecteur du cluster échappe les guillemets : seuls des tokens plats sans guillemets restent lisibles et cherchables.

## Changements

- Ligne d'accès applicative logfmt sur le canal monolog `access` (kernel.terminate) : method, path sans query string, status, duration_ms, route, request_id, user (UUID technique, omis si anonyme). Probes de santé exclues.
- `request_id` ajouté à l'extra de tous les logs monolog : header X-Request-Id de l'ingress (format validé, sinon UUID v7 généré), pour corréler ligne d'accès et logs applicatifs d'une même requête.
- Caddyfile : `trusted_proxies` (client_ip réel dans les logs, REMOTE_ADDR côté PHP inchangé, vérifié dans le source FrankenPHP), duration en ms, suppression des champs redondants (remote_ip, proto, XFF), `log_skip` des requêtes dynamiques.
- Doc : docs/developer/logs.md (format, corrélation, minimisation RGPD).

## Changement de comportement assumé

Caddy ne logge plus les requêtes servies par PHP : une seule ligne par requête (logfmt côté Symfony, JSON côté Caddy pour statiques/redirections/TRACE). Limite : une requête qui tue le process PHP (fatal dur, OOM) n'a plus de ligne d'accès, seule la trace stderr subsiste. Rollback : retirer `log_skip @phpHandled`.

## Validation

- `composer check-rules` et `fix-style` OK.
- Testé en dev : ligne d'accès correcte (200/404, route, durée), corrélation request_id sur tous les logs, header X-Request-Id forgé (espaces) rejeté au profit d'un id généré, health exclu.
- Caddyfile validé (Caddy 2.11.4) et testé sur une instance jetable : statique loggé avec client_ip résolu depuis XFF, requête dynamique non loggée par Caddy, 301 hérités et TRACE 405 toujours loggés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)