### PR TITLE
refactor(security): dérivation des infos datastore depuis l’appartenance de l’utilisateur (findMembership backend)

### DIFF
--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Exception\AppException;
 use App\Security\User;
-use App\Services\EntrepotApi\DatastoreApiService;
 use App\Services\MailerService;
 use App\Services\MembershipService;
 use Psr\Log\LoggerInterface;
@@ -285,20 +284,14 @@ class ContactController extends AbstractController
         name: 'datastore_deletion_request',
         methods: ['POST'],
     )]
-    public function datastoreDeletionRequest(Request $request, MembershipService $membershipService, DatastoreApiService $datastoreApiService): JsonResponse
+    public function datastoreDeletionRequest(Request $request, MembershipService $membershipService): JsonResponse
     {
         try {
             $data = json_decode($request->getContent(), true);
 
-            $membership = $membershipService->findByDatastore($data['datastoreId']);
-            if (null !== $membership) {
-                $datastoreName = $membership['community']['name'];
-                $communityId = $membership['community']['_id'];
-            } else {
-                $datastore = $datastoreApiService->get($data['datastoreId']);
-                $datastoreName = $datastore['name'];
-                $communityId = $datastore['community']['_id'];
-            }
+            $datastoreIdentity = $membershipService->getDatastoreIdentity($data['datastoreId']);
+            $datastoreName = $datastoreIdentity->name;
+            $communityId = $datastoreIdentity->communityId;
 
             $supportAddress = $this->getParameter('support_contact_mail');
             $now = new \DateTime();

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -290,8 +290,6 @@ class ContactController extends AbstractController
             $data = json_decode($request->getContent(), true);
 
             $datastoreIdentity = $membershipService->getDatastoreIdentity($data['datastoreId']);
-            $datastoreName = $datastoreIdentity->name;
-            $communityId = $datastoreIdentity->communityId;
 
             $supportAddress = $this->getParameter('support_contact_mail');
             $now = new \DateTime();
@@ -302,9 +300,9 @@ class ContactController extends AbstractController
             $mailParams = [
                 'sendDate' => $now,
                 'data' => $data,
-                'datastore_name' => $datastoreName,
+                'datastore_name' => $datastoreIdentity->name,
                 'datastore_id' => $data['datastoreId'],
-                'community_id' => $communityId,
+                'community_id' => $datastoreIdentity->communityId,
             ];
 
             $this->logger->info('datastore.deletion.request', [
@@ -313,7 +311,7 @@ class ContactController extends AbstractController
             ]);
 
             // Envoi du mail à l'adresse du support
-            $this->mailerService->sendMail($supportAddress, sprintf("[cartes.gouv.fr] Demande de suppression de l'entrepôt %s", $datastoreName), 'Mailer/datastore_delete_request/request.html.twig', $mailParams);
+            $this->mailerService->sendMail($supportAddress, sprintf("[cartes.gouv.fr] Demande de suppression de l'entrepôt %s", $datastoreIdentity->name), 'Mailer/datastore_delete_request/request.html.twig', $mailParams);
 
             // Envoi du mail d'accusé de réception à l'utilisateur
             $this->mailerService->sendMail($userEmail, '[cartes.gouv.fr] Accusé de réception de votre demande', 'Mailer/datastore_delete_request/request_acknowledgement.html.twig',

--- a/src/Controller/ContactController.php
+++ b/src/Controller/ContactController.php
@@ -5,8 +5,8 @@ namespace App\Controller;
 use App\Exception\AppException;
 use App\Security\User;
 use App\Services\EntrepotApi\DatastoreApiService;
-use App\Services\EntrepotApi\UserApiService;
 use App\Services\MailerService;
+use App\Services\MembershipService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -23,7 +23,6 @@ use Symfony\Component\Routing\Attribute\Route;
 class ContactController extends AbstractController
 {
     public function __construct(
-        private UserApiService $userApiService,
         private MailerService $mailerService,
         private LoggerInterface $logger,
     ) {
@@ -63,7 +62,6 @@ class ContactController extends AbstractController
             $supportAddress = $this->getParameter('support_contact_mail');
             $now = new \DateTime();
 
-            $userApi = null;
             $supportMailParams = [
                 'userEmail' => $userEmail,
                 'firstName' => $data['first_name'],
@@ -75,8 +73,7 @@ class ContactController extends AbstractController
             ];
 
             if ($user instanceof User) {
-                $userApi = $this->userApiService->getMe()->array();
-                $supportMailParams['userId'] = $userApi['_id'];
+                $supportMailParams['userId'] = $user->getId();
             }
 
             $this->logger->info('contact.request', [
@@ -116,10 +113,9 @@ class ContactController extends AbstractController
         $supervisor = [];   // Liste des community dont l'utilisateur courant est "supervisor"
         $member = [];       // Liste des community dont l'utilisateur courant est simple membre
         if ($user instanceof User) {
-            $userApi = $this->userApiService->getMe()->array();
-            foreach ($userApi['communities_member'] as $communityMember) {
+            foreach ($user->getCommunitiesMember() as $communityMember) {
                 $community = $communityMember['community'];
-                if ($userApi['_id'] === $community['supervisor']) {
+                if ($user->getId() === $community['supervisor']) {
                     $supervisor[$community['name']] = $community['_id'];
                 } else {
                     $member[$community['name']] = $community['_id'];
@@ -289,11 +285,20 @@ class ContactController extends AbstractController
         name: 'datastore_deletion_request',
         methods: ['POST'],
     )]
-    public function datastoreDeletionRequest(Request $request, DatastoreApiService $datastoreApiService): JsonResponse
+    public function datastoreDeletionRequest(Request $request, MembershipService $membershipService, DatastoreApiService $datastoreApiService): JsonResponse
     {
         try {
             $data = json_decode($request->getContent(), true);
-            $datastore = $datastoreApiService->get($data['datastoreId']);
+
+            $membership = $membershipService->findByDatastore($data['datastoreId']);
+            if (null !== $membership) {
+                $datastoreName = $membership['community']['name'];
+                $communityId = $membership['community']['_id'];
+            } else {
+                $datastore = $datastoreApiService->get($data['datastoreId']);
+                $datastoreName = $datastore['name'];
+                $communityId = $datastore['community']['_id'];
+            }
 
             $supportAddress = $this->getParameter('support_contact_mail');
             $now = new \DateTime();
@@ -304,9 +309,9 @@ class ContactController extends AbstractController
             $mailParams = [
                 'sendDate' => $now,
                 'data' => $data,
-                'datastore_name' => $datastore['name'],
-                'datastore_id' => $datastore['_id'],
-                'community_id' => $datastore['community']['_id'],
+                'datastore_name' => $datastoreName,
+                'datastore_id' => $data['datastoreId'],
+                'community_id' => $communityId,
             ];
 
             $this->logger->info('datastore.deletion.request', [
@@ -315,7 +320,7 @@ class ContactController extends AbstractController
             ]);
 
             // Envoi du mail à l'adresse du support
-            $this->mailerService->sendMail($supportAddress, sprintf("[cartes.gouv.fr] Demande de suppression de l'entrepôt %s", $datastore['name']), 'Mailer/datastore_delete_request/request.html.twig', $mailParams);
+            $this->mailerService->sendMail($supportAddress, sprintf("[cartes.gouv.fr] Demande de suppression de l'entrepôt %s", $datastoreName), 'Mailer/datastore_delete_request/request.html.twig', $mailParams);
 
             // Envoi du mail d'accusé de réception à l'utilisateur
             $this->mailerService->sendMail($userEmail, '[cartes.gouv.fr] Accusé de réception de votre demande', 'Mailer/datastore_delete_request/request_acknowledgement.html.twig',

--- a/src/Controller/Entrepot/AnnexeController.php
+++ b/src/Controller/Entrepot/AnnexeController.php
@@ -11,12 +11,10 @@ use App\Services\CswMetadataHelper;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
 use App\Services\EntrepotApi\MetadataApiService;
-use App\Services\MembershipService;
 use App\Services\RSSFeed\RSSFeed;
 use App\Utils;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,11 +36,9 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
 
     public function __construct(
         private AnnexeApiService $annexeApiService,
-        private MembershipService $membershipService,
         private MetadataApiService $metadataApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
         private CswMetadataHelper $metadataHelper,
-        private ParameterBagInterface $parameterBag,
         private RSSFeed $rssFeed,
     ) {
     }
@@ -160,9 +156,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
     public function addThumbnail(string $datastoreId, Request $request): JsonResponse
     {
         try {
-            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $datasheetName = $request->request->get('datasheetName');
-            $annexeUrl = $this->parameterBag->get('annexes_url');
 
             $uuid = Uuid::v4();
 
@@ -183,7 +177,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
             }
 
             $annexe = $this->annexeApiService->add($datastoreId, $file->getRealPath(), [$path], $labels);
-            $annexe['url'] = $annexeUrl.'/'.$datastoreTechnicalName.$annexe['paths'][0];
+            $annexe['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
 
             // Creation ou mise a jour des métadonnées
             $metadata = $this->cartesMetadataApiService->getMetadataByDatasheetName($datastoreId, $datasheetName);

--- a/src/Controller/Entrepot/AnnexeController.php
+++ b/src/Controller/Entrepot/AnnexeController.php
@@ -156,6 +156,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
     public function addThumbnail(string $datastoreId, Request $request): JsonResponse
     {
         try {
+            $annexesBaseUrl = $this->annexeApiService->getBaseUrl($datastoreId);
             $datasheetName = $request->request->get('datasheetName');
 
             $uuid = Uuid::v4();
@@ -177,7 +178,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
             }
 
             $annexe = $this->annexeApiService->add($datastoreId, $file->getRealPath(), [$path], $labels);
-            $annexe['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
+            $annexe['url'] = $annexesBaseUrl.$annexe['paths'][0];
 
             // Creation ou mise a jour des métadonnées
             $metadata = $this->cartesMetadataApiService->getMetadataByDatasheetName($datastoreId, $datasheetName);

--- a/src/Controller/Entrepot/AnnexeController.php
+++ b/src/Controller/Entrepot/AnnexeController.php
@@ -10,8 +10,8 @@ use App\Exception\CartesApiException;
 use App\Services\CswMetadataHelper;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
-use App\Services\EntrepotApi\DatastoreApiService;
 use App\Services\EntrepotApi\MetadataApiService;
+use App\Services\MembershipService;
 use App\Services\RSSFeed\RSSFeed;
 use App\Utils;
 use OpenApi\Attributes as OA;
@@ -38,7 +38,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
 
     public function __construct(
         private AnnexeApiService $annexeApiService,
-        private DatastoreApiService $datastoreApiService,
+        private MembershipService $membershipService,
         private MetadataApiService $metadataApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
         private CswMetadataHelper $metadataHelper,
@@ -160,7 +160,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
     public function addThumbnail(string $datastoreId, Request $request): JsonResponse
     {
         try {
-            $datastore = $this->datastoreApiService->get($datastoreId);
+            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $datasheetName = $request->request->get('datasheetName');
             $annexeUrl = $this->parameterBag->get('annexes_url');
 
@@ -183,7 +183,7 @@ class AnnexeController extends AbstractController implements ApiControllerInterf
             }
 
             $annexe = $this->annexeApiService->add($datastoreId, $file->getRealPath(), [$path], $labels);
-            $annexe['url'] = $annexeUrl.'/'.$datastore['technical_name'].$annexe['paths'][0];
+            $annexe['url'] = $annexeUrl.'/'.$datastoreTechnicalName.$annexe['paths'][0];
 
             // Creation ou mise a jour des métadonnées
             $metadata = $this->cartesMetadataApiService->getMetadataByDatasheetName($datastoreId, $datasheetName);

--- a/src/Controller/Entrepot/CommunityController.php
+++ b/src/Controller/Entrepot/CommunityController.php
@@ -48,6 +48,8 @@ class CommunityController extends AbstractController implements ApiControllerInt
         try {
             $data = json_decode($request->getContent(), true);
             $community = $this->communityApiService->modifyCommunity($communityId, $data)->array();
+            // le nom de la communauté fait partie des infos dérivées de l'appartenance
+            $this->membershipService->invalidateCurrentUser();
 
             return new JsonResponse($community);
         } catch (ApiException $ex) {
@@ -104,6 +106,10 @@ class CommunityController extends AbstractController implements ApiControllerInt
 
             $this->communityApiService->addOrModifyUserRights($communityId, $userId, ['rights' => $rights])->await();
 
+            if ($userId === $user->getId()) {
+                $this->membershipService->invalidateCurrentUser();
+            }
+
             return new JsonResponse([
                 'user' => $userId,
                 'rights' => $rights,
@@ -135,6 +141,10 @@ class CommunityController extends AbstractController implements ApiControllerInt
             }
 
             $this->communityApiService->removeUserRights($communityId, $userId)->await();
+
+            if ($userId === $user->getId()) {
+                $this->membershipService->invalidateCurrentUser();
+            }
 
             return new JsonResponse(['user' => $userId]);
         } catch (ApiException $ex) {

--- a/src/Controller/Entrepot/CommunityController.php
+++ b/src/Controller/Entrepot/CommunityController.php
@@ -6,8 +6,9 @@ use App\Constants\EntrepotApi\Community;
 use App\Controller\ApiControllerInterface;
 use App\Exception\ApiException;
 use App\Exception\CartesApiException;
+use App\Security\User;
 use App\Services\EntrepotApi\CommunityApiService;
-use App\Services\EntrepotApi\UserApiService;
+use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,7 +26,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
 {
     public function __construct(
         private CommunityApiService $communityApiService,
-        private UserApiService $userApiService,
+        private MembershipService $membershipService,
     ) {
     }
 
@@ -70,18 +71,17 @@ class CommunityController extends AbstractController implements ApiControllerInt
     public function updateMember(string $communityId, Request $request): JsonResponse
     {
         try {
-            $me = $this->userApiService->getMe()->array();
+            $user = $this->getUser();
+            assert($user instanceof User);
 
             // Suis-je membre de cette communaute
-            $communityMember = array_values(array_filter($me['communities_member'], function ($member) use ($communityId) {
-                return $member['community']['_id'] == $communityId;
-            }));
-            if (0 === count($communityMember)) {
+            $membership = $this->membershipService->findByCommunity($communityId);
+            if (null === $membership) {
                 throw new CartesApiException("Vous n'êtes pas membre de cette communauté", JsonResponse::HTTP_BAD_REQUEST);
             }
 
             // Ai-je le droit de modifier les membres ?
-            if (!$this->_allowedToModifyMembers($communityMember[0], $me)) {
+            if (!$this->_allowedToModifyMembers($membership, $user->getId())) {
                 throw new CartesApiException("Vous n'avez pas les droits pour ajouter un utilisateur ou modifier ses permissions", JsonResponse::HTTP_BAD_REQUEST);
             }
 
@@ -117,13 +117,12 @@ class CommunityController extends AbstractController implements ApiControllerInt
     public function removeMember(string $communityId, Request $request): JsonResponse
     {
         try {
-            $me = $this->userApiService->getMe()->array();
+            $user = $this->getUser();
+            assert($user instanceof User);
 
             // Suis-je membre de cette communaute
-            $communityMember = array_values(array_filter($me['communities_member'], function ($member) use ($communityId) {
-                return $member['community']['_id'] == $communityId;
-            }));
-            if (0 === count($communityMember)) {
+            $membership = $this->membershipService->findByCommunity($communityId);
+            if (null === $membership) {
                 throw new CartesApiException("Vous n'êtes pas membre de cette communauté", JsonResponse::HTTP_BAD_REQUEST);
             }
 
@@ -131,7 +130,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
             $userId = $data['user_id'];
 
             // Ai-je le droit de modifier les membres ?
-            if ($me['_id'] !== $userId && !$this->_allowedToModifyMembers($communityMember[0], $me)) {
+            if ($user->getId() !== $userId && !$this->_allowedToModifyMembers($membership, $user->getId())) {
                 throw new CartesApiException("Vous n'avez pas les droits pour supprimer un membre de cette communauté", JsonResponse::HTTP_BAD_REQUEST);
             }
 
@@ -164,18 +163,17 @@ class CommunityController extends AbstractController implements ApiControllerInt
      *  - si je suis superviseur
      *  - si j'ai le droit COMMUNITY
      *
-     * @param array<mixed> $communityMember
-     * @param array<mixed> $me
+     * @param array<mixed> $membership
      *
      * @return bool
      */
-    private function _allowedToModifyMembers($communityMember, $me)
+    private function _allowedToModifyMembers($membership, ?string $myUserId)
     {
-        if ($me['_id'] === $communityMember['community']['supervisor']) {
+        if ($myUserId === $membership['community']['supervisor']) {
             return true;
         }
 
-        if (in_array('COMMUNITY', $communityMember['rights'])) {
+        if (in_array('COMMUNITY', $membership['rights'])) {
             return true;
         }
 

--- a/src/Controller/Entrepot/CommunityController.php
+++ b/src/Controller/Entrepot/CommunityController.php
@@ -177,7 +177,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
      *
      * @return bool
      */
-    private function _allowedToModifyMembers($membership, ?string $myUserId)
+    private function _allowedToModifyMembers($membership, string $myUserId)
     {
         if ($myUserId === $membership['community']['supervisor']) {
             return true;

--- a/src/Controller/Entrepot/DatasheetController.php
+++ b/src/Controller/Entrepot/DatasheetController.php
@@ -12,10 +12,10 @@ use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesServiceApiService;
 use App\Services\EntrepotApi\CartesStoredDataApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
-use App\Services\EntrepotApi\DatastoreApiService;
 use App\Services\EntrepotApi\MetadataApiService;
 use App\Services\EntrepotApi\StoredDataApiService;
 use App\Services\EntrepotApi\UploadApiService;
+use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,7 +34,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
     public function __construct(
         private UploadApiService $uploadApiService,
         private StoredDataApiService $storedDataApiService,
-        private DatastoreApiService $datastoreApiService,
+        private MembershipService $membershipService,
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesServiceApiService $cartesServiceApiService,
@@ -91,13 +91,13 @@ class DatasheetController extends AbstractController implements ApiControllerInt
 
         $datasheetList = [];
 
-        $datastore = $this->datastoreApiService->get($datastoreId);
+        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
 
         $configurations = $pendingConfigurations->resolve();
         $annexes = $pendingAnnexes->resolve();
 
         foreach ($uniqueDatasheetNames as $datasheetName) {
-            $datasheetList[] = $this->getBasicInfo($datastore, $datasheetName, $configurations, $annexes);
+            $datasheetList[] = $this->getBasicInfo($datastoreId, $datastoreTechnicalName, $datasheetName, $configurations, $annexes);
         }
 
         return $this->json($datasheetList);
@@ -153,8 +153,8 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             }
         }
 
-        $datastore = $this->datastoreApiService->get($datastoreId);
-        $datasheet = $this->getBasicInfo($datastore, $datasheetName);
+        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
+        $datasheet = $this->getBasicInfo($datastoreId, $datastoreTechnicalName, $datasheetName);
 
         return $this->json([
             ...$datasheet,
@@ -204,11 +204,10 @@ class DatasheetController extends AbstractController implements ApiControllerInt
     }
 
     /**
-     * @param array<mixed>         $datastore
      * @param ?array<array<mixed>> $configurations
      * @param ?array<array<mixed>> $annexes
      */
-    private function getBasicInfo(array $datastore, string $datasheetName, ?array $configurations = null, ?array $annexes = null): array
+    private function getBasicInfo(string $datastoreId, string $datastoreTechnicalName, string $datasheetName, ?array $configurations = null, ?array $annexes = null): array
     {
         // recherche du nombre de services publiés à partir de $configurations si fourni, sinon requête API
         if (null !== $configurations) {
@@ -220,7 +219,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
                 return false;
             });
         } else {
-            $datasheetConfigurations = $this->configurationApiService->getAll($datastore['_id'], [
+            $datasheetConfigurations = $this->configurationApiService->getAll($datastoreId, [
                 'tags' => [
                     CommonTags::DATASHEET_NAME => $datasheetName,
                 ],
@@ -237,13 +236,13 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             });
             $datasheetAnnexes = array_values($datasheetAnnexes);
         } else {
-            $datasheetAnnexes = $this->annexeApiService->getAll($datastore['_id'], null, null, ["datasheet_name=$datasheetName", 'type=thumbnail'])->resolve();
+            $datasheetAnnexes = $this->annexeApiService->getAll($datastoreId, null, null, ["datasheet_name=$datasheetName", 'type=thumbnail'])->resolve();
         }
 
         $thumbnail = null;
         if (count($datasheetAnnexes) > 0) {
             $thumbnail = $datasheetAnnexes[0];
-            $thumbnail['url'] = $annexeUrl.'/'.$datastore['technical_name'].$thumbnail['paths'][0];
+            $thumbnail['url'] = $annexeUrl.'/'.$datastoreTechnicalName.$thumbnail['paths'][0];
         }
 
         return [

--- a/src/Controller/Entrepot/DatasheetController.php
+++ b/src/Controller/Entrepot/DatasheetController.php
@@ -15,7 +15,6 @@ use App\Services\EntrepotApi\ConfigurationApiService;
 use App\Services\EntrepotApi\MetadataApiService;
 use App\Services\EntrepotApi\StoredDataApiService;
 use App\Services\EntrepotApi\UploadApiService;
-use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -34,7 +33,6 @@ class DatasheetController extends AbstractController implements ApiControllerInt
     public function __construct(
         private UploadApiService $uploadApiService,
         private StoredDataApiService $storedDataApiService,
-        private MembershipService $membershipService,
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesServiceApiService $cartesServiceApiService,
@@ -91,13 +89,11 @@ class DatasheetController extends AbstractController implements ApiControllerInt
 
         $datasheetList = [];
 
-        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
-
         $configurations = $pendingConfigurations->resolve();
         $annexes = $pendingAnnexes->resolve();
 
         foreach ($uniqueDatasheetNames as $datasheetName) {
-            $datasheetList[] = $this->getBasicInfo($datastoreId, $datastoreTechnicalName, $datasheetName, $configurations, $annexes);
+            $datasheetList[] = $this->getBasicInfo($datastoreId, $datasheetName, $configurations, $annexes);
         }
 
         return $this->json($datasheetList);
@@ -153,8 +149,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             }
         }
 
-        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
-        $datasheet = $this->getBasicInfo($datastoreId, $datastoreTechnicalName, $datasheetName);
+        $datasheet = $this->getBasicInfo($datastoreId, $datasheetName);
 
         return $this->json([
             ...$datasheet,
@@ -207,7 +202,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
      * @param ?array<array<mixed>> $configurations
      * @param ?array<array<mixed>> $annexes
      */
-    private function getBasicInfo(string $datastoreId, string $datastoreTechnicalName, string $datasheetName, ?array $configurations = null, ?array $annexes = null): array
+    private function getBasicInfo(string $datastoreId, string $datasheetName, ?array $configurations = null, ?array $annexes = null): array
     {
         // recherche du nombre de services publiés à partir de $configurations si fourni, sinon requête API
         if (null !== $configurations) {
@@ -229,7 +224,6 @@ class DatasheetController extends AbstractController implements ApiControllerInt
         $nbPublications = count($datasheetConfigurations);
 
         // recherche de vignette à partir de $annexes si fourni, sinon requête API
-        $annexeUrl = $this->getParameter('annexes_url');
         if (null !== $annexes) {
             $datasheetAnnexes = array_filter($annexes, function ($annexe) use ($datasheetName) {
                 return in_array(CommonTags::DATASHEET_NAME."=$datasheetName", $annexe['labels']);
@@ -242,7 +236,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
         $thumbnail = null;
         if (count($datasheetAnnexes) > 0) {
             $thumbnail = $datasheetAnnexes[0];
-            $thumbnail['url'] = $annexeUrl.'/'.$datastoreTechnicalName.$thumbnail['paths'][0];
+            $thumbnail['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $thumbnail);
         }
 
         return [

--- a/src/Controller/Entrepot/DatasheetDocumentController.php
+++ b/src/Controller/Entrepot/DatasheetDocumentController.php
@@ -7,7 +7,6 @@ use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
-use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -29,17 +28,14 @@ use Symfony\Component\Uid\Uuid;
 class DatasheetDocumentController extends AbstractController implements ApiControllerInterface
 {
     private string $varDataPath;
-    private string $annexesBaseUrl;
 
     public function __construct(
         private AnnexeApiService $annexeApiService,
-        private MembershipService $membershipService,
         private CartesMetadataApiService $cartesMetadataApiService,
         private Filesystem $fs,
         ParameterBagInterface $parameters,
     ) {
         $this->varDataPath = $parameters->get('datasheet_documents_path');
-        $this->annexesBaseUrl = $parameters->get('annexes_url');
     }
 
     #[Route('', name: 'get_list', methods: ['GET'])]
@@ -106,10 +102,8 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
 
                     $fileAnnexe = $this->annexeApiService->add($datastoreId, $tempFilePath, [$annexePath], ["datasheet_name=$datasheetName", 'type=document'], true);
 
-                    $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
-
                     $newDocument['id'] = $fileAnnexe['_id'];
-                    $newDocument['url'] = $this->annexesBaseUrl.'/'.$datastoreTechnicalName.$fileAnnexe['paths'][0];
+                    $newDocument['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $fileAnnexe);
 
                     break;
             }

--- a/src/Controller/Entrepot/DatasheetDocumentController.php
+++ b/src/Controller/Entrepot/DatasheetDocumentController.php
@@ -7,7 +7,7 @@ use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
-use App\Services\EntrepotApi\DatastoreApiService;
+use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -33,7 +33,7 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
 
     public function __construct(
         private AnnexeApiService $annexeApiService,
-        private DatastoreApiService $datastoreApiService,
+        private MembershipService $membershipService,
         private CartesMetadataApiService $cartesMetadataApiService,
         private Filesystem $fs,
         ParameterBagInterface $parameters,
@@ -66,8 +66,6 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
             $documentDescription = $request->request->get('description');
 
             $files = $request->files;
-
-            $datastore = $this->datastoreApiService->get($datastoreId);
 
             /** @var array<mixed> $listAnnexe entité annexe de l'API entrepôt */
             $listAnnexe = $this->getListAnnexe($datastoreId, $datasheetName);
@@ -108,8 +106,10 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
 
                     $fileAnnexe = $this->annexeApiService->add($datastoreId, $tempFilePath, [$annexePath], ["datasheet_name=$datasheetName", 'type=document'], true);
 
+                    $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
+
                     $newDocument['id'] = $fileAnnexe['_id'];
-                    $newDocument['url'] = $this->annexesBaseUrl.'/'.$datastore['technical_name'].$fileAnnexe['paths'][0];
+                    $newDocument['url'] = $this->annexesBaseUrl.'/'.$datastoreTechnicalName.$fileAnnexe['paths'][0];
 
                     break;
             }

--- a/src/Controller/Entrepot/DatasheetDocumentController.php
+++ b/src/Controller/Entrepot/DatasheetDocumentController.php
@@ -100,10 +100,11 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
 
                     $annexePath = join('/', ['documents', $datasheetName, $uuid, $file->getClientOriginalName()]);
 
+                    $annexesBaseUrl = $this->annexeApiService->getBaseUrl($datastoreId);
                     $fileAnnexe = $this->annexeApiService->add($datastoreId, $tempFilePath, [$annexePath], ["datasheet_name=$datasheetName", 'type=document'], true);
 
                     $newDocument['id'] = $fileAnnexe['_id'];
-                    $newDocument['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $fileAnnexe);
+                    $newDocument['url'] = $annexesBaseUrl.$fileAnnexe['paths'][0];
 
                     break;
             }

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -10,7 +10,6 @@ use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
 use App\Services\EntrepotApi\CartesStylesApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
-use App\Services\MembershipService;
 use App\Utils;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -28,7 +27,6 @@ use Symfony\Component\Routing\Attribute\Route;
 class StyleController extends AbstractController implements ApiControllerInterface
 {
     public function __construct(
-        private MembershipService $membershipService,
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
@@ -48,7 +46,6 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             /** @var array<string,mixed> */
             $styleFiles = $data['style_files'];
 
-            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
             $datasheetName = $configuration['tags'][CommonTags::DATASHEET_NAME];
@@ -61,7 +58,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], 'mapbox' === $layerName ? 'json' : $layer['format']);
                 $layerData = [
                     'annexe_id' => $annexe['_id'],
-                    'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe),
+                    'url' => $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe),
                 ];
 
                 if ('mapbox' !== $layerName) {
@@ -104,7 +101,6 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             /** @var array<string,mixed> */
             $styleFiles = $data['style_files'];
 
-            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configId = $offering['configuration']['_id'];
             $configuration = $this->configurationApiService->get($datastoreId, $configId)->array();
@@ -126,7 +122,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             if ('mapbox' === array_key_first($styleFiles)) {
                 $mapboxLayer = &$existingStyle['layers'][0];
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $styleFiles['mapbox']['style'], 'json', $mapboxLayer['annexe_id']);
-                $mapboxLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe);
+                $mapboxLayer['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
             } else {
                 foreach ($styleFiles as $layerName => $layer) {
                     $existingStyleLayerKey = Utils::array_find_key($existingStyle['layers'], fn ($l) => $l['name'] === $layerName);
@@ -134,14 +130,14 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                         // Si le layer existe, on met à jour son contenu
                         $existingStyleLayer = &$existingStyle['layers'][$existingStyleLayerKey];
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format'], $existingStyleLayer['annexe_id']);
-                        $existingStyleLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe);
+                        $existingStyleLayer['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
                     } else {
                         // Si le layer n'existe pas, on l'ajoute
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format']);
 
                         $layerData = [
                             'annexe_id' => $annexe['_id'],
-                            'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe),
+                            'url' => $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe),
                             'name' => $layerName,
                         ];
 

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -10,7 +10,7 @@ use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
 use App\Services\EntrepotApi\CartesStylesApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
-use App\Services\EntrepotApi\DatastoreApiService;
+use App\Services\MembershipService;
 use App\Utils;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -28,7 +28,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class StyleController extends AbstractController implements ApiControllerInterface
 {
     public function __construct(
-        private DatastoreApiService $datastoreApiService,
+        private MembershipService $membershipService,
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
@@ -48,7 +48,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             /** @var array<string,mixed> */
             $styleFiles = $data['style_files'];
 
-            $datastore = $this->datastoreApiService->get($datastoreId);
+            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
             $datasheetName = $configuration['tags'][CommonTags::DATASHEET_NAME];
@@ -61,7 +61,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], 'mapbox' === $layerName ? 'json' : $layer['format']);
                 $layerData = [
                     'annexe_id' => $annexe['_id'],
-                    'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastore, $annexe),
+                    'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe),
                 ];
 
                 if ('mapbox' !== $layerName) {
@@ -104,7 +104,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             /** @var array<string,mixed> */
             $styleFiles = $data['style_files'];
 
-            $datastore = $this->datastoreApiService->get($datastoreId);
+            $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configId = $offering['configuration']['_id'];
             $configuration = $this->configurationApiService->get($datastoreId, $configId)->array();
@@ -126,7 +126,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             if ('mapbox' === array_key_first($styleFiles)) {
                 $mapboxLayer = &$existingStyle['layers'][0];
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $styleFiles['mapbox']['style'], 'json', $mapboxLayer['annexe_id']);
-                $mapboxLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastore, $annexe);
+                $mapboxLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe);
             } else {
                 foreach ($styleFiles as $layerName => $layer) {
                     $existingStyleLayerKey = Utils::array_find_key($existingStyle['layers'], fn ($l) => $l['name'] === $layerName);
@@ -134,14 +134,14 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                         // Si le layer existe, on met à jour son contenu
                         $existingStyleLayer = &$existingStyle['layers'][$existingStyleLayerKey];
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format'], $existingStyleLayer['annexe_id']);
-                        $existingStyleLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastore, $annexe);
+                        $existingStyleLayer['url'] = $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe);
                     } else {
                         // Si le layer n'existe pas, on l'ajoute
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format']);
 
                         $layerData = [
                             'annexe_id' => $annexe['_id'],
-                            'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastore, $annexe),
+                            'url' => $this->cartesStylesApiService->getAnnexeAbsoluteUrl($datastoreTechnicalName, $annexe),
                             'name' => $layerName,
                         ];
 

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -49,6 +49,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
             $datasheetName = $configuration['tags'][CommonTags::DATASHEET_NAME];
+            $annexesBaseUrl = $this->annexeApiService->getBaseUrl($datastoreId);
 
             $styles = $this->cartesStylesApiService->getStyles($datastoreId, $configuration);
             $this->cleanStyleTags($styles);
@@ -58,7 +59,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], 'mapbox' === $layerName ? 'json' : $layer['format']);
                 $layerData = [
                     'annexe_id' => $annexe['_id'],
-                    'url' => $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe),
+                    'url' => $annexesBaseUrl.$annexe['paths'][0],
                 ];
 
                 if ('mapbox' !== $layerName) {
@@ -105,6 +106,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $configId = $offering['configuration']['_id'];
             $configuration = $this->configurationApiService->get($datastoreId, $configId)->array();
             $datasheetName = $configuration['tags'][CommonTags::DATASHEET_NAME];
+            $annexesBaseUrl = $this->annexeApiService->getBaseUrl($datastoreId);
 
             // Recuperation des styles de la configuration
             $styles = $this->cartesStylesApiService->getStyles($datastoreId, $configuration);
@@ -122,7 +124,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             if ('mapbox' === array_key_first($styleFiles)) {
                 $mapboxLayer = &$existingStyle['layers'][0];
                 $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $styleFiles['mapbox']['style'], 'json', $mapboxLayer['annexe_id']);
-                $mapboxLayer['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
+                $mapboxLayer['url'] = $annexesBaseUrl.$annexe['paths'][0];
             } else {
                 foreach ($styleFiles as $layerName => $layer) {
                     $existingStyleLayerKey = Utils::array_find_key($existingStyle['layers'], fn ($l) => $l['name'] === $layerName);
@@ -130,14 +132,14 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                         // Si le layer existe, on met à jour son contenu
                         $existingStyleLayer = &$existingStyle['layers'][$existingStyleLayerKey];
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format'], $existingStyleLayer['annexe_id']);
-                        $existingStyleLayer['url'] = $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe);
+                        $existingStyleLayer['url'] = $annexesBaseUrl.$annexe['paths'][0];
                     } else {
                         // Si le layer n'existe pas, on l'ajoute
                         $annexe = $this->cartesStylesApiService->saveStyleInAnnexe($datastoreId, $datasheetName, $styleTechnicalName, $layer['style'], $layer['format']);
 
                         $layerData = [
                             'annexe_id' => $annexe['_id'],
-                            'url' => $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexe),
+                            'url' => $annexesBaseUrl.$annexe['paths'][0],
                             'name' => $layerName,
                         ];
 

--- a/src/Controller/Entrepot/UserController.php
+++ b/src/Controller/Entrepot/UserController.php
@@ -7,10 +7,10 @@ use App\Controller\ApiControllerInterface;
 use App\Dto\User\UserKeyDTO;
 use App\Exception\ApiException;
 use App\Exception\CartesApiException;
-use App\Security\EntrepotUserCache;
 use App\Security\User;
 use App\Services\EntrepotApi\ServiceAccount;
 use App\Services\EntrepotApi\UserApiService;
+use App\Services\MembershipService;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -29,7 +29,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
 {
     public function __construct(
         private UserApiService $userApiService,
-        private EntrepotUserCache $entrepotUserCache,
+        private MembershipService $membershipService,
     ) {
     }
 
@@ -44,11 +44,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
         assert($user instanceof User);
 
         // rafraîchit à travers le cache serveur pour qu'il voie aussi la donnée fraîche
-        $keycloakId = $user->getKeycloakId();
-        $apiUserInfo = null !== $keycloakId
-            ? $this->entrepotUserCache->refresh($keycloakId)
-            : $this->userApiService->getMe()->array();
-        $user->updateFromApiInfo($apiUserInfo);
+        $this->membershipService->refreshCurrentUser();
 
         return $this->json($user);
     }
@@ -216,7 +212,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
     public function addMemberToSandbox(ServiceAccount $serviceAccount): JsonResponse
     {
         $serviceAccount->addCurrentUserToSandbox();
-        $this->invalidateUserCache();
+        $this->membershipService->invalidateCurrentUser();
 
         return new JsonResponse();
     }
@@ -226,19 +222,11 @@ class UserController extends AbstractController implements ApiControllerInterfac
     {
         try {
             $this->userApiService->leaveCommunity($communityId)->await();
-            $this->invalidateUserCache();
+            $this->membershipService->invalidateCurrentUser();
 
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
         } catch (ApiException $ex) {
             throw new CartesApiException($ex->getMessage(), $ex->getStatusCode(), $ex->getDetails(), $ex);
-        }
-    }
-
-    private function invalidateUserCache(): void
-    {
-        $user = $this->getUser();
-        if ($user instanceof User && null !== $user->getKeycloakId()) {
-            $this->entrepotUserCache->invalidate($user->getKeycloakId());
         }
     }
 

--- a/src/Controller/Entrepot/UserController.php
+++ b/src/Controller/Entrepot/UserController.php
@@ -7,6 +7,7 @@ use App\Controller\ApiControllerInterface;
 use App\Dto\User\UserKeyDTO;
 use App\Exception\ApiException;
 use App\Exception\CartesApiException;
+use App\Security\EntrepotUserCache;
 use App\Security\User;
 use App\Services\EntrepotApi\ServiceAccount;
 use App\Services\EntrepotApi\UserApiService;
@@ -28,6 +29,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
 {
     public function __construct(
         private UserApiService $userApiService,
+        private EntrepotUserCache $entrepotUserCache,
     ) {
     }
 
@@ -40,7 +42,13 @@ class UserController extends AbstractController implements ApiControllerInterfac
         }
 
         assert($user instanceof User);
-        $user->updateFromApiInfo($this->userApiService->getMe()->array());
+
+        // rafraîchit à travers le cache serveur pour qu'il voie aussi la donnée fraîche
+        $keycloakId = $user->getKeycloakId();
+        $apiUserInfo = null !== $keycloakId
+            ? $this->entrepotUserCache->refresh($keycloakId)
+            : $this->userApiService->getMe()->array();
+        $user->updateFromApiInfo($apiUserInfo);
 
         return $this->json($user);
     }

--- a/src/Controller/Entrepot/UserController.php
+++ b/src/Controller/Entrepot/UserController.php
@@ -216,6 +216,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
     public function addMemberToSandbox(ServiceAccount $serviceAccount): JsonResponse
     {
         $serviceAccount->addCurrentUserToSandbox();
+        $this->invalidateUserCache();
 
         return new JsonResponse();
     }
@@ -225,10 +226,19 @@ class UserController extends AbstractController implements ApiControllerInterfac
     {
         try {
             $this->userApiService->leaveCommunity($communityId)->await();
+            $this->invalidateUserCache();
 
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
         } catch (ApiException $ex) {
             throw new CartesApiException($ex->getMessage(), $ex->getStatusCode(), $ex->getDetails(), $ex);
+        }
+    }
+
+    private function invalidateUserCache(): void
+    {
+        $user = $this->getUser();
+        if ($user instanceof User && null !== $user->getKeycloakId()) {
+            $this->entrepotUserCache->invalidate($user->getKeycloakId());
         }
     }
 

--- a/src/Dto/Datastore/DatastoreIdentity.php
+++ b/src/Dto/Datastore/DatastoreIdentity.php
@@ -2,9 +2,6 @@
 
 namespace App\Dto\Datastore;
 
-/**
- * Identité d'un datastore telle que dérivée de l'appartenance de l'utilisateur (ou du DTO Entrepôt en secours).
- */
 final readonly class DatastoreIdentity
 {
     public function __construct(

--- a/src/Dto/Datastore/DatastoreIdentity.php
+++ b/src/Dto/Datastore/DatastoreIdentity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Dto\Datastore;
+
+/**
+ * Identité d'un datastore telle que dérivée de l'appartenance de l'utilisateur (ou du DTO Entrepôt en secours).
+ */
+final readonly class DatastoreIdentity
+{
+    public function __construct(
+        public string $name,
+        public string $technicalName,
+        public string $communityId,
+    ) {
+    }
+}

--- a/src/Security/EntrepotUserCache.php
+++ b/src/Security/EntrepotUserCache.php
@@ -65,11 +65,9 @@ class EntrepotUserCache
     {
         return $this->cache->get(self::CACHE_KEY_PREFIX.$keycloakId, function (ItemInterface $item) {
             $item->expiresAfter(self::TTL);
+            $data = $this->userApiService->getMe()->array();
 
-            return [
-                'fetched_at' => time(),
-                'data' => $this->userApiService->getMe()->array(),
-            ];
+            return ['fetched_at' => time(), 'data' => $data];
         }, $beta);
     }
 }

--- a/src/Security/EntrepotUserCache.php
+++ b/src/Security/EntrepotUserCache.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Security;
+
+use App\Services\EntrepotApi\UserApiService;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Cache serveur de la réponse GET users/me de l'API Entrepôt, clé par identifiant Keycloak.
+ */
+class EntrepotUserCache
+{
+    private const CACHE_KEY_PREFIX = 'user-me-';
+    private const TTL = 60;
+    private const REFRESH_THROTTLE = 10;
+
+    public function __construct(
+        private UserApiService $userApiService,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function get(string $keycloakId): array
+    {
+        return $this->doGet($keycloakId)['data'];
+    }
+
+    /**
+     * Recalcule l'entrée immédiatement, sans la supprimer (garde la protection contre les recalculs concurrents).
+     *
+     * @return array<mixed>
+     */
+    public function refresh(string $keycloakId): array
+    {
+        return $this->doGet($keycloakId, INF)['data'];
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function refreshThrottled(string $keycloakId): array
+    {
+        $entry = $this->doGet($keycloakId);
+
+        if (time() - $entry['fetched_at'] < self::REFRESH_THROTTLE) {
+            return $entry['data'];
+        }
+
+        return $this->refresh($keycloakId);
+    }
+
+    public function invalidate(string $keycloakId): void
+    {
+        $this->cache->delete(self::CACHE_KEY_PREFIX.$keycloakId);
+    }
+
+    /**
+     * @return array{fetched_at:int,data:array<mixed>}
+     */
+    private function doGet(string $keycloakId, ?float $beta = null): array
+    {
+        return $this->cache->get(self::CACHE_KEY_PREFIX.$keycloakId, function (ItemInterface $item) {
+            $item->expiresAfter(self::TTL);
+
+            return [
+                'fetched_at' => time(),
+                'data' => $this->userApiService->getMe()->array(),
+            ];
+        }, $beta);
+    }
+}

--- a/src/Security/KeycloakUserProvider.php
+++ b/src/Security/KeycloakUserProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Security;
 
-use App\Services\EntrepotApi\UserApiService;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\Provider\KeycloakClient;
 use Psr\Log\LoggerInterface;
@@ -28,7 +27,7 @@ class KeycloakUserProvider implements UserProviderInterface
         private ClientRegistry $clientRegistry,
         private KeycloakTokenManager $tokenManager,
         private ParameterBagInterface $params,
-        private UserApiService $userApiService,
+        private EntrepotUserCache $entrepotUserCache,
         private LoggerInterface $logger,
         private CacheInterface $cache,
     ) {
@@ -62,16 +61,12 @@ class KeycloakUserProvider implements UserProviderInterface
             throw new AuthenticationExpiredException('Failed to fetch user from token', Response::HTTP_UNAUTHORIZED, $th);
         }
 
-        $apiUser = $this->cache->get("users-{$keycloakUser->getId()}", function (ItemInterface $item) {
-            $item->expiresAfter(60);
-
-            try {
-                return $this->userApiService->getMe()->array();
-            } catch (TimeoutException $ex) {
-                $this->logger->debug('{class}: Failed to fetch logged-in user', ['class' => self::class]);
-                throw new UserNotFoundException('Failed to fetch logged-in user', Response::HTTP_UNAUTHORIZED, $ex);
-            }
-        });
+        try {
+            $apiUser = $this->entrepotUserCache->get($keycloakUser->getId());
+        } catch (TimeoutException $ex) {
+            $this->logger->debug('{class}: Failed to fetch logged-in user', ['class' => self::class]);
+            throw new UserNotFoundException('Failed to fetch logged-in user', Response::HTTP_UNAUTHORIZED, $ex);
+        }
 
         $user = new User($keycloakUser->toArray(), $apiUser);
 

--- a/src/Security/KeycloakUserProvider.php
+++ b/src/Security/KeycloakUserProvider.php
@@ -6,7 +6,6 @@ use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use KnpU\OAuth2ClientBundle\Client\Provider\KeycloakClient;
 use Psr\Log\LoggerInterface;
 use Stevenmaguire\OAuth2\Client\Provider\KeycloakResourceOwner;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpClient\Exception\TimeoutException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
@@ -26,7 +25,6 @@ class KeycloakUserProvider implements UserProviderInterface
     public function __construct(
         private ClientRegistry $clientRegistry,
         private KeycloakTokenManager $tokenManager,
-        private ParameterBagInterface $params,
         private EntrepotUserCache $entrepotUserCache,
         private LoggerInterface $logger,
         private CacheInterface $cache,
@@ -35,11 +33,6 @@ class KeycloakUserProvider implements UserProviderInterface
 
     public function loadUser(): User
     {
-        //  création d'un utilisateur bidon si en mode test
-        if ('test' === $this->params->get('app_env')) {
-            return User::getTestUser();
-        }
-
         /** @var KeycloakClient */
         $keycloakClient = $this->clientRegistry->getClient('keycloak');
 

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -21,13 +21,13 @@ class User implements UserInterface
     /** @var array<mixed> */
     private array $communitiesMember = [];
 
-    private ?\DateTimeInterface $accountCreationDate;
-    private ?\DateTimeInterface $lastLoginDate;
+    private ?\DateTimeInterface $accountCreationDate = null;
+    private ?\DateTimeInterface $lastLoginDate = null;
 
-    private ?int $documentsQuota;
-    private ?int $documentsUse;
-    private ?int $keysQuota;
-    private ?int $keysUse;
+    private ?int $documentsQuota = null;
+    private ?int $documentsUse = null;
+    private ?int $keysQuota = null;
+    private ?int $keysUse = null;
 
     /**
      * @param array<mixed> $keycloakUserInfo

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -3,12 +3,14 @@
 namespace App\Security;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Serializer\Attribute\Ignore;
 
 class User implements UserInterface
 {
     private string $email;
     private string $userName;
     private string $id;
+    private ?string $keycloakId;
 
     /** @var array<string> */
     private array $roles = [];
@@ -34,6 +36,7 @@ class User implements UserInterface
     public function __construct(array $keycloakUserInfo = [], array $apiUserInfo = [])
     {
         $this->email = $keycloakUserInfo['email'];
+        $this->keycloakId = $keycloakUserInfo['sub'] ?? null;
         $this->id = $apiUserInfo['_id'];
         $this->firstName = $keycloakUserInfo['given_name'] ?? null;
         $this->lastName = $keycloakUserInfo['family_name'] ?? null;
@@ -116,6 +119,12 @@ class User implements UserInterface
         return $this->id;
     }
 
+    #[Ignore]
+    public function getKeycloakId(): ?string
+    {
+        return $this->keycloakId;
+    }
+
     public function getFirstName(): ?string
     {
         return $this->firstName;
@@ -192,6 +201,7 @@ class User implements UserInterface
     {
         return new User([
             'email' => 'test@test.com',
+            'sub' => '3f3ba6e0-38b9-4e26-8b29-7c9d26f42c46',
             'given_name' => 'Test',
             'family_name' => 'User',
             'preferred_username' => 'test_user',

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -211,6 +211,9 @@ class User implements UserInterface
         if (array_key_exists('communities_member', $apiUserInfo)) {
             $this->communitiesMember = $apiUserInfo['communities_member'];
         }
+        if (array_key_exists('last_login', $apiUserInfo)) {
+            $this->lastLoginDate = new \DateTime($apiUserInfo['last_login']);
+        }
         if (array_key_exists('documents_quota', $apiUserInfo)) {
             $this->documentsQuota = $apiUserInfo['documents_quota'];
         }

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Security;
 
+use App\Utils;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Attribute\Ignore;
 
@@ -10,7 +11,7 @@ class User implements UserInterface
     private string $email;
     private string $userName;
     private string $id;
-    private ?string $keycloakId;
+    private string $keycloakId;
 
     /** @var array<string> */
     private array $roles = [];
@@ -36,41 +37,16 @@ class User implements UserInterface
     public function __construct(array $keycloakUserInfo = [], array $apiUserInfo = [])
     {
         $this->email = $keycloakUserInfo['email'];
-        $this->keycloakId = $keycloakUserInfo['sub'] ?? null;
+        $this->keycloakId = $keycloakUserInfo['sub'];
         $this->id = $apiUserInfo['_id'];
         $this->firstName = $keycloakUserInfo['given_name'] ?? null;
         $this->lastName = $keycloakUserInfo['family_name'] ?? null;
         $this->userName = $keycloakUserInfo['preferred_username'];
-        $this->accountCreationDate = null;
-        $this->lastLoginDate = null;
-
         if (array_key_exists('creation', $apiUserInfo)) {
             $this->accountCreationDate = new \DateTime($apiUserInfo['creation']);
         }
 
-        if (array_key_exists('last_login', $apiUserInfo)) {
-            $this->lastLoginDate = new \DateTime($apiUserInfo['last_login']);
-        }
-
-        if (array_key_exists('documents_quota', $apiUserInfo)) {
-            $this->documentsQuota = $apiUserInfo['documents_quota'];
-        }
-
-        if (array_key_exists('documents_use', $apiUserInfo)) {
-            $this->documentsUse = $apiUserInfo['documents_use'];
-        }
-
-        if (array_key_exists('keys_quota', $apiUserInfo)) {
-            $this->keysQuota = $apiUserInfo['keys_quota'];
-        }
-
-        if (array_key_exists('keys_use', $apiUserInfo)) {
-            $this->keysUse = $apiUserInfo['keys_use'];
-        }
-
-        if (array_key_exists('communities_member', $apiUserInfo)) {
-            $this->communitiesMember = $apiUserInfo['communities_member'];
-        }
+        $this->updateFromApiInfo($apiUserInfo);
     }
 
     public function getEmail(): ?string
@@ -120,7 +96,7 @@ class User implements UserInterface
     }
 
     #[Ignore]
-    public function getKeycloakId(): ?string
+    public function getKeycloakId(): string
     {
         return $this->keycloakId;
     }
@@ -150,13 +126,7 @@ class User implements UserInterface
      */
     public function findMembershipByDatastore(string $datastoreId): ?array
     {
-        foreach ($this->communitiesMember as $member) {
-            if (($member['community']['datastore'] ?? null) === $datastoreId) {
-                return $member;
-            }
-        }
-
-        return null;
+        return $this->findMembership('datastore', $datastoreId);
     }
 
     /**
@@ -164,13 +134,15 @@ class User implements UserInterface
      */
     public function findMembershipByCommunity(string $communityId): ?array
     {
-        foreach ($this->communitiesMember as $member) {
-            if (($member['community']['_id'] ?? null) === $communityId) {
-                return $member;
-            }
-        }
+        return $this->findMembership('_id', $communityId);
+    }
 
-        return null;
+    /**
+     * @return array<mixed>|null
+     */
+    private function findMembership(string $communityKey, string $value): ?array
+    {
+        return Utils::array_find($this->communitiesMember, fn (array $member) => ($member['community'][$communityKey] ?? null) === $value);
     }
 
     public function getAccountCreationDate(): ?\DateTimeInterface

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -143,6 +143,36 @@ class User implements UserInterface
         return $this->communitiesMember;
     }
 
+    /**
+     * `community.datastore` est un id string dans users/me, absent si la communauté n'a pas de datastore.
+     *
+     * @return array<mixed>|null
+     */
+    public function findMembershipByDatastore(string $datastoreId): ?array
+    {
+        foreach ($this->communitiesMember as $member) {
+            if (($member['community']['datastore'] ?? null) === $datastoreId) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function findMembershipByCommunity(string $communityId): ?array
+    {
+        foreach ($this->communitiesMember as $member) {
+            if (($member['community']['_id'] ?? null) === $communityId) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+
     public function getAccountCreationDate(): ?\DateTimeInterface
     {
         return $this->accountCreationDate;

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -229,34 +229,4 @@ class User implements UserInterface
 
         return $this;
     }
-
-    public static function getTestUser(): User
-    {
-        return new User([
-            'email' => 'test@test.com',
-            'sub' => '3f3ba6e0-38b9-4e26-8b29-7c9d26f42c46',
-            'given_name' => 'Test',
-            'family_name' => 'User',
-            'preferred_username' => 'test_user',
-        ], [
-            '_id' => 'fc5a7948-142a-4dae-b24e-5550fe7183f9',
-            'creation' => '2023-06-26T11:52:25.924679Z',
-            'last_login' => '2023-08-01T14:09:41.074381Z',
-            'communities_member' => [[
-                'rights' => ['ANNEX', 'BROADCAST', 'PROCESSING', 'UPLOAD'],
-                'community' => [
-                    'name' => 'cartes.gouv - dev',
-                    'technical_name' => 'cartes-gouv-dev',
-                    'datastore' => '190b714d-daa7-402b-8360-c75baa4c69cc',
-                    'supervisor' => '6b3637ed-c1cf-409c-a54c-fb77d4c16ea6',
-                    'public' => true,
-                    '_id' => 'a0f47300-4c9b-464a-b23f-639ccfa6a673',
-                ],
-            ]],
-            'documents_quota' => 50000000,
-            'documents_use' => 0,
-            'keys_quota' => 1000,
-            'keys_use' => 3,
-        ]);
-    }
 }

--- a/src/Services/EntrepotApi/AnnexeApiService.php
+++ b/src/Services/EntrepotApi/AnnexeApiService.php
@@ -23,13 +23,19 @@ final class AnnexeApiService
     }
 
     /**
-     * URL publique d'une annexe ; le nom technique du datastore vient de l'appartenance de l'utilisateur.
-     *
+     * Préfixe des URL publiques des annexes du datastore ; à résoudre avant un effet de bord pour ne pas laisser d'annexe orpheline.
+     */
+    public function getBaseUrl(string $datastoreId): string
+    {
+        return $this->annexesUrl.'/'.$this->membershipService->getDatastoreIdentity($datastoreId)->technicalName;
+    }
+
+    /**
      * @param array<mixed> $annexe
      */
     public function getAbsoluteUrl(string $datastoreId, array $annexe): string
     {
-        return $this->annexesUrl.'/'.$this->membershipService->getDatastoreIdentity($datastoreId)->technicalName.$annexe['paths'][0];
+        return $this->getBaseUrl($datastoreId).$annexe['paths'][0];
     }
 
     /**

--- a/src/Services/EntrepotApi/AnnexeApiService.php
+++ b/src/Services/EntrepotApi/AnnexeApiService.php
@@ -6,6 +6,7 @@ use App\ApiClient\ApiClient;
 use App\ApiClient\PaginatedPromise;
 use App\ApiClient\PaginatedResponse;
 use App\ApiClient\ResponsePromise;
+use App\Services\MembershipService;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -15,7 +16,20 @@ final class AnnexeApiService
         #[Autowire(service: 'app.api_client.entrepot')]
         public readonly ApiClient $api,
         private readonly Filesystem $filesystem,
+        private readonly MembershipService $membershipService,
+        #[Autowire('%annexes_url%')]
+        private readonly string $annexesUrl,
     ) {
+    }
+
+    /**
+     * URL publique d'une annexe ; le nom technique du datastore vient de l'appartenance de l'utilisateur.
+     *
+     * @param array<mixed> $annexe
+     */
+    public function getAbsoluteUrl(string $datastoreId, array $annexe): string
+    {
+        return $this->annexesUrl.'/'.$this->membershipService->getDatastoreIdentity($datastoreId)->technicalName.$annexe['paths'][0];
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -16,7 +16,6 @@ use App\Entity\CswMetadata\CswStyleFile;
 use App\Exception\AppException;
 use App\Exception\CartesApiException;
 use App\Services\CswMetadataHelper;
-use App\Services\MembershipService;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -37,7 +36,6 @@ class CartesMetadataApiService
         private CswMetadataHelper $cswMetadataHelper,
         private CartesStylesApiService $cartesStylesApiService,
         private StoredDataApiService $storedDataApiService,
-        private MembershipService $membershipService,
     ) {
     }
 
@@ -72,11 +70,7 @@ class CartesMetadataApiService
             return null;
         }
 
-        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
-
-        $annexeUrl = $this->parameterBag->get('annexes_url');
-
-        return $annexeUrl.'/'.$datastoreTechnicalName.$annexeList[0]['paths'][0];
+        return $this->annexeApiService->getAbsoluteUrl($datastoreId, $annexeList[0]);
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -16,6 +16,7 @@ use App\Entity\CswMetadata\CswStyleFile;
 use App\Exception\AppException;
 use App\Exception\CartesApiException;
 use App\Services\CswMetadataHelper;
+use App\Services\MembershipService;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -36,6 +37,7 @@ class CartesMetadataApiService
         private CswMetadataHelper $cswMetadataHelper,
         private CartesStylesApiService $cartesStylesApiService,
         private StoredDataApiService $storedDataApiService,
+        private MembershipService $membershipService,
     ) {
     }
 
@@ -70,11 +72,11 @@ class CartesMetadataApiService
             return null;
         }
 
-        $datastore = $this->datastoreApiService->get($datastoreId);
+        $datastoreTechnicalName = $this->membershipService->getDatastoreTechnicalName($datastoreId);
 
         $annexeUrl = $this->parameterBag->get('annexes_url');
 
-        return $annexeUrl.'/'.$datastore['technical_name'].$annexeList[0]['paths'][0];
+        return $annexeUrl.'/'.$datastoreTechnicalName.$annexeList[0]['paths'][0];
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -579,7 +579,7 @@ class CartesServiceApiService
      */
     private function addPermissionForCurrentCommunity(string $datastoreId, array $offering): void
     {
-        $communityId = $this->membershipService->getDatastoreCommunityId($datastoreId);
+        $communityId = $this->membershipService->getDatastoreIdentity($datastoreId)->communityId;
         $this->addPermissionForCommunity($datastoreId, $communityId, $offering);
     }
 

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -17,6 +17,7 @@ use App\Entity\CswMetadata\CswMetadataLayer;
 use App\Exception\CartesApiException;
 use App\Services\CapabilitiesService;
 use App\Services\GeonetworkApiService;
+use App\Services\MembershipService;
 use App\Services\SandboxService;
 use App\Utils;
 use Psr\Log\LoggerInterface;
@@ -49,6 +50,7 @@ class CartesServiceApiService
         private SandboxService $sandboxService,
         private CartesStylesApiService $cartesStylesApiService,
         private GeonetworkApiService $geonetworkApiService,
+        private MembershipService $membershipService,
         private CacheInterface $cache,
         private LoggerInterface $logger,
         HttpClientInterface $httpClient,
@@ -577,8 +579,8 @@ class CartesServiceApiService
      */
     private function addPermissionForCurrentCommunity(string $datastoreId, array $offering): void
     {
-        $datastore = $this->datastoreApiService->get($datastoreId);
-        $this->addPermissionForCommunity($datastoreId, $datastore['community']['_id'], $offering);
+        $communityId = $this->membershipService->getDatastoreCommunityId($datastoreId);
+        $this->addPermissionForCommunity($datastoreId, $communityId, $offering);
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesStylesApiService.php
+++ b/src/Services/EntrepotApi/CartesStylesApiService.php
@@ -190,12 +190,11 @@ class CartesStylesApiService
     }
 
     /**
-     * @param array<mixed> $datastore
      * @param array<mixed> $annexe
      */
-    public function getAnnexeAbsoluteUrl(array $datastore, array $annexe): string
+    public function getAnnexeAbsoluteUrl(string $datastoreTechnicalName, array $annexe): string
     {
-        return $this->parameters->get('annexes_url').'/'.$datastore['technical_name'].$annexe['paths'][0];
+        return $this->parameters->get('annexes_url').'/'.$datastoreTechnicalName.$annexe['paths'][0];
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesStylesApiService.php
+++ b/src/Services/EntrepotApi/CartesStylesApiService.php
@@ -190,14 +190,6 @@ class CartesStylesApiService
     }
 
     /**
-     * @param array<mixed> $annexe
-     */
-    public function getAnnexeAbsoluteUrl(string $datastoreTechnicalName, array $annexe): string
-    {
-        return $this->parameters->get('annexes_url').'/'.$datastoreTechnicalName.$annexe['paths'][0];
-    }
-
-    /**
      * Ajout d'un fichier de style sous forme d'annexe.
      */
     public function saveStyleInAnnexe(string $datastoreId, string $datasheetName, string $styleTechnicalName, string $content, string $extension, ?string $existingAnnexeId = null): array

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -4,6 +4,7 @@ namespace App\Services\EntrepotApi;
 
 use App\Exception\ApiException;
 use App\Security\User;
+use App\Services\MembershipService;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpClient\Exception\JsonException;
@@ -27,6 +28,7 @@ class ServiceAccount
     public function __construct(
         private ParameterBagInterface $parameters,
         private Security $security,
+        private MembershipService $membershipService,
     ) {
         // L'id de la community liee au datastore "Bac à sable"
         $sandbox = $this->parameters->get('sandbox');
@@ -58,6 +60,8 @@ class ServiceAccount
             throw new AccessDeniedException();
         }
 
+        // lecture fraîche : le token peut encore lister une appartenance quittée il y a moins de 60 s sur un autre pod
+        $this->membershipService->refreshCurrentUser();
         if (null !== $user->findMembershipByCommunity($this->sandBoxCommunityId)) {
             return;
         }

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -3,6 +3,8 @@
 namespace App\Services\EntrepotApi;
 
 use App\Exception\ApiException;
+use App\Security\User;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\HttpClient;
@@ -17,9 +19,6 @@ class ServiceAccount
     private $apiClient;
 
     /** @var array<mixed> */
-    private $me;
-
-    /** @var array<mixed> */
     private $token;
 
     /** @var string */
@@ -27,7 +26,7 @@ class ServiceAccount
 
     public function __construct(
         private ParameterBagInterface $parameters,
-        private UserApiService $userApiService,
+        private Security $security,
     ) {
         // L'id de la community liee au datastore "Bac à sable"
         $sandbox = $this->parameters->get('sandbox');
@@ -40,8 +39,6 @@ class ServiceAccount
             'verify_peer' => false,
             'verify_host' => false,
         ]);
-
-        $this->me = $this->userApiService->getMe()->array();
 
         // Recuperation du token du compte de service
         $this->token = $this->getAccessToken();
@@ -56,15 +53,12 @@ class ServiceAccount
             throw new AccessDeniedException();
         }
 
-        $alreadyMember = false;
-        foreach ($this->me['communities_member'] as $member) {
-            if ($this->sandBoxCommunityId == $member['community']['_id']) {
-                $alreadyMember = true;
-                break;
-            }
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new AccessDeniedException();
         }
 
-        if ($alreadyMember) {
+        if (null !== $user->findMembershipByCommunity($this->sandBoxCommunityId)) {
             return;
         }
 
@@ -72,7 +66,7 @@ class ServiceAccount
             'rights' => ['ANNEX', 'BROADCAST', 'PROCESSING', 'UPLOAD'],
         ]);
 
-        $response = $this->apiClient->request('PUT', "communities/{$this->sandBoxCommunityId}/users/{$this->me['_id']}", $options);
+        $response = $this->apiClient->request('PUT', "communities/{$this->sandBoxCommunityId}/users/{$user->getId()}", $options);
         $this->handleResponse($response);
     }
 

--- a/src/Services/EntrepotApi/UserApiService.php
+++ b/src/Services/EntrepotApi/UserApiService.php
@@ -20,22 +20,6 @@ final class UserApiService
         return $this->api->get('users/me');
     }
 
-    /**
-     * @SuppressWarnings(ShortVariable)
-     */
-    public function getMyCommunityRights(string $communityId): ?array
-    {
-        $me = $this->getMe()->array();
-
-        foreach ($me['communities_member'] as $communityRights) {
-            if ($communityRights['community']['_id'] == $communityId) {
-                return $communityRights;
-            }
-        }
-
-        return null;
-    }
-
     public function getMyKey(string $keyId): ResponsePromise
     {
         return $this->api->get("users/me/keys/$keyId");

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -6,12 +6,10 @@ use App\Dto\Datastore\DatastoreIdentity;
 use App\Security\EntrepotUserCache;
 use App\Security\User;
 use App\Services\EntrepotApi\DatastoreApiService;
-use App\Services\EntrepotApi\UserApiService;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
- * Dérive les infos datastore/communauté de l'appartenance de l'utilisateur courant,
- * au lieu de charger le DTO datastore complet depuis l'API Entrepôt.
+ * Dérive les infos datastore/communauté de l'appartenance de l'utilisateur courant, au lieu de charger le DTO datastore complet.
  */
 class MembershipService
 {
@@ -19,7 +17,6 @@ class MembershipService
         private Security $security,
         private EntrepotUserCache $entrepotUserCache,
         private DatastoreApiService $datastoreApiService,
-        private UserApiService $userApiService,
     ) {
     }
 
@@ -59,23 +56,13 @@ class MembershipService
         return new DatastoreIdentity($datastore['name'], $datastore['technical_name'], $datastore['community']['_id']);
     }
 
-    public function getDatastoreTechnicalName(string $datastoreId): string
-    {
-        return $this->getDatastoreIdentity($datastoreId)->technicalName;
-    }
-
-    public function getDatastoreCommunityId(string $datastoreId): string
-    {
-        return $this->getDatastoreIdentity($datastoreId)->communityId;
-    }
-
     /**
      * À appeler après une mutation d'appartenance faite par l'utilisateur lui-même.
      */
     public function invalidateCurrentUser(): void
     {
         $user = $this->security->getUser();
-        if ($user instanceof User && null !== $user->getKeycloakId()) {
+        if ($user instanceof User) {
             $this->entrepotUserCache->invalidate($user->getKeycloakId());
         }
     }
@@ -90,16 +77,11 @@ class MembershipService
             return;
         }
 
-        $keycloakId = $user->getKeycloakId();
-        $apiUserInfo = null !== $keycloakId
-            ? $this->entrepotUserCache->refresh($keycloakId)
-            : $this->userApiService->getMe()->array();
-        $user->updateFromApiInfo($apiUserInfo);
+        $user->updateFromApiInfo($this->entrepotUserCache->refresh($user->getKeycloakId()));
     }
 
     /**
-     * Cherche dans le token, puis re-vérifie une fois avec des données fraîches si absent
-     * (l'appartenance a pu changer il y a moins de 60 s, le TTL du cache).
+     * Cherche dans le token, puis une fois avec des données fraîches si absent (l'appartenance a pu changer depuis moins de 60 s).
      *
      * @param callable(User): (array<mixed>|null) $lookup
      *
@@ -117,12 +99,7 @@ class MembershipService
             return $membership;
         }
 
-        $keycloakId = $user->getKeycloakId();
-        if (null === $keycloakId) {
-            return null;
-        }
-
-        $user->updateFromApiInfo($this->entrepotUserCache->refreshThrottled($keycloakId));
+        $user->updateFromApiInfo($this->entrepotUserCache->refreshThrottled($user->getKeycloakId()));
 
         return $lookup($user);
     }

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Dto\Datastore\DatastoreIdentity;
 use App\Security\EntrepotUserCache;
 use App\Security\User;
 use App\Services\EntrepotApi\DatastoreApiService;
@@ -36,29 +37,34 @@ class MembershipService
         return $this->find(fn (User $user) => $user->findMembershipByCommunity($communityId));
     }
 
-    public function getDatastoreTechnicalName(string $datastoreId): string
+    /**
+     * Nom, nom technique et communauté du datastore, depuis l'appartenance ; sinon un seul chargement du DTO Entrepôt.
+     */
+    public function getDatastoreIdentity(string $datastoreId): DatastoreIdentity
     {
         $membership = $this->findByDatastore($datastoreId);
         if (null !== $membership) {
-            return $membership['community']['technical_name'];
+            return new DatastoreIdentity(
+                $membership['community']['name'],
+                $membership['community']['technical_name'],
+                $membership['community']['_id'],
+            );
         }
 
         // non-membre : on laisse l'API Entrepôt répondre elle-même (succès ou erreur)
         $datastore = $this->datastoreApiService->get($datastoreId);
 
-        return $datastore['technical_name'];
+        return new DatastoreIdentity($datastore['name'], $datastore['technical_name'], $datastore['community']['_id']);
+    }
+
+    public function getDatastoreTechnicalName(string $datastoreId): string
+    {
+        return $this->getDatastoreIdentity($datastoreId)->technicalName;
     }
 
     public function getDatastoreCommunityId(string $datastoreId): string
     {
-        $membership = $this->findByDatastore($datastoreId);
-        if (null !== $membership) {
-            return $membership['community']['_id'];
-        }
-
-        $datastore = $this->datastoreApiService->get($datastoreId);
-
-        return $datastore['community']['_id'];
+        return $this->getDatastoreIdentity($datastoreId)->communityId;
     }
 
     /**

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services;
+
+use App\Security\EntrepotUserCache;
+use App\Security\User;
+use App\Services\EntrepotApi\DatastoreApiService;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * Dérive les infos datastore/communauté de l'appartenance de l'utilisateur courant,
+ * au lieu de charger le DTO datastore complet depuis l'API Entrepôt.
+ */
+class MembershipService
+{
+    public function __construct(
+        private Security $security,
+        private EntrepotUserCache $entrepotUserCache,
+        private DatastoreApiService $datastoreApiService,
+    ) {
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function findByDatastore(string $datastoreId): ?array
+    {
+        return $this->find(fn (User $user) => $user->findMembershipByDatastore($datastoreId));
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function findByCommunity(string $communityId): ?array
+    {
+        return $this->find(fn (User $user) => $user->findMembershipByCommunity($communityId));
+    }
+
+    public function getDatastoreTechnicalName(string $datastoreId): string
+    {
+        $membership = $this->findByDatastore($datastoreId);
+        if (null !== $membership) {
+            return $membership['community']['technical_name'];
+        }
+
+        // non-membre : on laisse l'API Entrepôt répondre elle-même (succès ou erreur)
+        $datastore = $this->datastoreApiService->get($datastoreId);
+
+        return $datastore['technical_name'];
+    }
+
+    public function getDatastoreCommunityId(string $datastoreId): string
+    {
+        $membership = $this->findByDatastore($datastoreId);
+        if (null !== $membership) {
+            return $membership['community']['_id'];
+        }
+
+        $datastore = $this->datastoreApiService->get($datastoreId);
+
+        return $datastore['community']['_id'];
+    }
+
+    /**
+     * Cherche dans le token, puis re-vérifie une fois avec des données fraîches si absent
+     * (l'appartenance a pu changer il y a moins de 60 s, le TTL du cache).
+     *
+     * @param callable(User): (array<mixed>|null) $lookup
+     *
+     * @return array<mixed>|null
+     */
+    private function find(callable $lookup): ?array
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return null;
+        }
+
+        $membership = $lookup($user);
+        if (null !== $membership) {
+            return $membership;
+        }
+
+        $keycloakId = $user->getKeycloakId();
+        if (null === $keycloakId) {
+            return null;
+        }
+
+        $user->updateFromApiInfo($this->entrepotUserCache->refreshThrottled($keycloakId));
+
+        return $lookup($user);
+    }
+}

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -6,6 +6,7 @@ use App\Dto\Datastore\DatastoreIdentity;
 use App\Security\EntrepotUserCache;
 use App\Security\User;
 use App\Services\EntrepotApi\DatastoreApiService;
+use App\Services\EntrepotApi\UserApiService;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
@@ -18,6 +19,7 @@ class MembershipService
         private Security $security,
         private EntrepotUserCache $entrepotUserCache,
         private DatastoreApiService $datastoreApiService,
+        private UserApiService $userApiService,
     ) {
     }
 
@@ -76,6 +78,23 @@ class MembershipService
         if ($user instanceof User && null !== $user->getKeycloakId()) {
             $this->entrepotUserCache->invalidate($user->getKeycloakId());
         }
+    }
+
+    /**
+     * Recharge users/me à travers le cache serveur et met à jour l'utilisateur du token.
+     */
+    public function refreshCurrentUser(): void
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $keycloakId = $user->getKeycloakId();
+        $apiUserInfo = null !== $keycloakId
+            ? $this->entrepotUserCache->refresh($keycloakId)
+            : $this->userApiService->getMe()->array();
+        $user->updateFromApiInfo($apiUserInfo);
     }
 
     /**

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -62,6 +62,17 @@ class MembershipService
     }
 
     /**
+     * À appeler après une mutation d'appartenance faite par l'utilisateur lui-même.
+     */
+    public function invalidateCurrentUser(): void
+    {
+        $user = $this->security->getUser();
+        if ($user instanceof User && null !== $user->getKeycloakId()) {
+            $this->entrepotUserCache->invalidate($user->getKeycloakId());
+        }
+    }
+
+    /**
      * Cherche dans le token, puis re-vérifie une fois avec des données fraîches si absent
      * (l'appartenance a pu changer il y a moins de 60 s, le TTL du cache).
      *

--- a/src/Workflow/UploadIntegrationWorkflow.php
+++ b/src/Workflow/UploadIntegrationWorkflow.php
@@ -285,7 +285,7 @@ class UploadIntegrationWorkflow
         if (isset($upload['tags']['email_notification']) && filter_var($upload['tags']['email_notification'], FILTER_VALIDATE_BOOLEAN)) {
             /** @var \App\Security\User|null */
             $user = $this->security->getUser();
-            $userEmail = $user->getEmail();
+            $userEmail = $user?->getEmail();
             $datasheetName = $upload['tags'][CommonTags::DATASHEET_NAME] ?? null;
 
             if ($userEmail && $datasheetName) {


### PR DESCRIPTION
Le token porte déjà `communities_member` (jamais lu jusqu’ici) : les contrôleurs qui ne lisaient que `technical_name` / `name` / `community._id` du DTO datastore les dérivent désormais de l’appartenance de l’utilisateur, au lieu de recharger le DTO complet depuis l’API Entrepôt. Ça retire ~10 appels API par parcours et surtout l’appel `GET datastores/{id}` de la liste des fiches de données (clé de cache `datastore-{id}` sous verrou anti-stampede, amont observé à 8-30 s).

**Changements**
- `User` : `findMembershipByDatastore` / `findMembershipByCommunity`, identifiant Keycloak stocké, `updateFromApiInfo` met aussi à jour `last_login`.
- `EntrepotUserCache` : cache serveur de `users/me` extrait du provider (clé `user-me-{keycloakId}`, TTL 60 s, `refresh` forcé sous le même verrou, `refreshThrottled` 10 s, `invalidate`).
- `MembershipService` : dérivation avec revalidation throttlée sur absence puis repli sur le vrai `DatastoreApiService::get()` (réponse amont authentique) ; `DatastoreIdentity` (nom, nom technique, communauté), seul point d’entrée `getDatastoreIdentity()` ; `refreshCurrentUser` / `invalidateCurrentUser` ; `keycloakId` non nullable (Keycloak envoie toujours `sub`).
- `GET /api/users/me` : write-through dans le cache serveur (auparavant `getMe()` contournait le cache sans le mettre à jour).
- Invalidation du cache après les mutations d’appartenance faites par l’utilisateur lui-même (ajout sandbox, quitter une communauté, `updateMember` / `removeMember` sur soi, `modify` de communauté).
- Sites convertis : `DatasheetController::getBasicInfo`, `AnnexeController::addThumbnail`, `DatasheetDocumentController::add`, `StyleController` ; URL d’annexe calculée par `AnnexeApiService::getAbsoluteUrl($datastoreId, $annexe)` : aucun contrôleur ne lit plus `technical_name`, `CartesMetadataApiService::getThumbnailUrl`, `CartesServiceApiService::addPermissionForCurrentCommunity`, `ContactController` ; les 4 filtres `communities_member` inline sur `getMe()` passent par le token.
- `ServiceAccount` sans `getMe()` au constructeur ; `getMyCommunityRights` (sans appelant) et `getTestUser` + bypass test du provider supprimés ; propriétés nullables de `User` initialisées.

**Changements de comportement assumés**
- Ordre des clés du JSON `users/me` modifié (`user_identifier` en dernier) ; contenu identique.
- Les vérifications superviseur de `updateMember` / `removeMember` lisent le token (≤ 60 s de retard possible) au lieu d’un `getMe()` live ; l’API Entrepôt reste l’arbitre.
- En prod, `cache.app` est APCu (par pod) : l’invalidation après mutation ne vaut que pour le pod qui l’a servie ; le write-through de `users/me` et la revalidation sur absence sont par requête et fonctionnent sur tous les pods.

**Validation**
`composer check-rules` ; passe manuelle : quitter le bac à sable puis le rejoindre depuis la tuile (chemins revoke et grant du cache d’appartenance), liste des fiches de données, dépôt et intégration d’une donnée, modification d’un service.