### PR TITLE
refactor(sandbox): compte de service via ApiClientFactory, ServiceAccount et SandboxService allégés

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,6 +35,10 @@ services:
         class: App\ApiClient\ApiClient
         factory: ['@App\ApiClient\ApiClientFactory', "createEspaceCoStyleClient"]
 
+    app.api_client.entrepot_sandbox_service_account:
+        class: App\ApiClient\ApiClient
+        factory: ['@App\ApiClient\ApiClientFactory', "createSandboxServiceAccountClient"]
+
     # Formatter du canal access : message logfmt seul, la ligne doit rester brute pour Loki
     app.monolog.access_line_formatter:
         class: Monolog\Formatter\LineFormatter

--- a/src/ApiClient/ApiClientFactory.php
+++ b/src/ApiClient/ApiClientFactory.php
@@ -52,14 +52,39 @@ final class ApiClientFactory
         return new ApiClient($authenticated, new EspaceCoErrorParser(), $this->logger);
     }
 
+    /**
+     * Client Entrepôt authentifié par le compte de service du bac à sable (token client_credentials, obtenu au premier appel).
+     */
+    public function createSandboxServiceAccountClient(): ApiClient
+    {
+        $tokenClient = $this->scopedClient(sprintf(
+            '%s/realms/%s/protocol/openid-connect',
+            (string) $this->parameters->get('iam_url'),
+            (string) $this->parameters->get('iam_realm'),
+        ));
+        $credentials = $this->parameters->get('sandbox_service_account');
+
+        $authenticated = new ServiceAccountHttpClient(
+            $this->scopedClient((string) $this->parameters->get('api_entrepot_url')),
+            $tokenClient,
+            (string) ($credentials['client_id'] ?? ''),
+            (string) ($credentials['client_secret'] ?? ''),
+        );
+
+        return new ApiClient($authenticated, new EntrepotErrorParser(), $this->logger);
+    }
+
     private function buildAuthenticatedClient(string $urlParameter): AuthenticatedHttpClient
     {
-        $scoped = $this->httpClient->withOptions([
-            'base_uri' => (string) $this->parameters->get($urlParameter).'/',
+        return new AuthenticatedHttpClient($this->scopedClient((string) $this->parameters->get($urlParameter)), $this->tokenManager);
+    }
+
+    private function scopedClient(string $baseUrl): HttpClientInterface
+    {
+        return $this->httpClient->withOptions([
+            'base_uri' => $baseUrl.'/',
             'proxy' => $this->parameters->get('http_proxy'),
             'no_proxy' => $this->parameters->get('no_proxy'),
         ]);
-
-        return new AuthenticatedHttpClient($scoped, $this->tokenManager);
     }
 }

--- a/src/ApiClient/ApiClientFactory.php
+++ b/src/ApiClient/ApiClientFactory.php
@@ -39,22 +39,11 @@ final class ApiClientFactory
     public function createEspaceCoStyleClient(): ApiClient
     {
         $baseUrl = str_replace('/api', '/style', (string) $this->parameters->get('api_espaceco_url'));
-        $scoped = $this->httpClient->withOptions([
-            'base_uri' => $baseUrl.'/',
-            'proxy' => $this->parameters->get('http_proxy'),
-            'no_proxy' => $this->parameters->get('no_proxy'),
-            // 'verify_peer' => false,
-            // 'verify_host' => false,
-        ]);
-
-        $authenticated = new AuthenticatedHttpClient($scoped, $this->tokenManager);
+        $authenticated = new AuthenticatedHttpClient($this->scopedClient($baseUrl), $this->tokenManager);
 
         return new ApiClient($authenticated, new EspaceCoErrorParser(), $this->logger);
     }
 
-    /**
-     * Client Entrepôt authentifié par le compte de service du bac à sable (token client_credentials, obtenu au premier appel).
-     */
     public function createSandboxServiceAccountClient(): ApiClient
     {
         $tokenClient = $this->scopedClient(sprintf(
@@ -67,8 +56,8 @@ final class ApiClientFactory
         $authenticated = new ServiceAccountHttpClient(
             $this->scopedClient((string) $this->parameters->get('api_entrepot_url')),
             $tokenClient,
-            (string) ($credentials['client_id'] ?? ''),
-            (string) ($credentials['client_secret'] ?? ''),
+            (string) $credentials['client_id'],
+            (string) $credentials['client_secret'],
         );
 
         return new ApiClient($authenticated, new EntrepotErrorParser(), $this->logger);

--- a/src/ApiClient/ServiceAccountAuthenticationException.php
+++ b/src/ApiClient/ServiceAccountAuthenticationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\ApiClient;
+
+/**
+ * Le compte de service n'a pas pu obtenir de token auprès de Keycloak.
+ */
+final class ServiceAccountAuthenticationException extends \RuntimeException
+{
+}

--- a/src/ApiClient/ServiceAccountHttpClient.php
+++ b/src/ApiClient/ServiceAccountHttpClient.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\ApiClient;
+
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+/**
+ * Authentifie les appels avec le token client_credentials d'un compte de service Keycloak, obtenu au premier appel.
+ */
+final class ServiceAccountHttpClient implements HttpClientInterface
+{
+    private ?string $accessToken = null;
+
+    public function __construct(
+        private HttpClientInterface $inner,
+        private HttpClientInterface $tokenClient,
+        private string $clientId,
+        #[\SensitiveParameter] private string $clientSecret,
+    ) {
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $options['headers'] ??= [];
+        $options['headers']['Authorization'] = "Bearer {$this->getAccessToken()}";
+
+        return $this->inner->request($method, $url, $options);
+    }
+
+    public function stream(iterable|ResponseInterface $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        return $this->inner->stream($responses, $timeout);
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        $clone = clone $this;
+        $clone->inner = $this->inner->withOptions($options);
+
+        return $clone;
+    }
+
+    /**
+     * @throws AccessDeniedException si le compte de service ne peut pas s'authentifier
+     */
+    private function getAccessToken(): string
+    {
+        if (null !== $this->accessToken) {
+            return $this->accessToken;
+        }
+
+        try {
+            $response = $this->tokenClient->request('POST', 'token', [
+                'body' => [
+                    'grant_type' => 'client_credentials',
+                    'client_id' => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                ],
+                'headers' => ['Accept' => 'application/json'],
+            ]);
+            $accessToken = $response->toArray()['access_token'] ?? null;
+        } catch (ExceptionInterface $e) {
+            throw new AccessDeniedException('Compte de service : échec de l\'authentification', $e);
+        }
+
+        if (!is_string($accessToken) || '' === $accessToken) {
+            throw new AccessDeniedException('Compte de service : token absent de la réponse');
+        }
+
+        return $this->accessToken = $accessToken;
+    }
+}

--- a/src/ApiClient/ServiceAccountHttpClient.php
+++ b/src/ApiClient/ServiceAccountHttpClient.php
@@ -2,7 +2,6 @@
 
 namespace App\ApiClient;
 
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -51,7 +50,7 @@ final class ServiceAccountHttpClient implements HttpClientInterface
     }
 
     /**
-     * @throws AccessDeniedException si le compte de service ne peut pas s'authentifier
+     * @throws ServiceAccountAuthenticationException
      */
     private function getAccessToken(): string
     {
@@ -70,11 +69,11 @@ final class ServiceAccountHttpClient implements HttpClientInterface
             ]);
             $accessToken = $response->toArray()['access_token'] ?? null;
         } catch (ExceptionInterface $e) {
-            throw new AccessDeniedException('Compte de service : échec de l\'authentification', $e);
+            throw new ServiceAccountAuthenticationException('Compte de service : échec de l\'authentification', 0, $e);
         }
 
         if (!is_string($accessToken) || '' === $accessToken) {
-            throw new AccessDeniedException('Compte de service : token absent de la réponse');
+            throw new ServiceAccountAuthenticationException('Compte de service : token absent de la réponse');
         }
 
         return $this->accessToken = $accessToken;

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -2,57 +2,41 @@
 
 namespace App\Services\EntrepotApi;
 
-use App\Exception\ApiException;
+use App\ApiClient\ApiClient;
 use App\Security\User;
 use App\Services\MembershipService;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
-use Symfony\Component\HttpClient\Exception\JsonException;
-use Symfony\Component\HttpClient\HttpClient;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * Actions faites au nom du compte de service du bac à sable (et non de l'utilisateur connecté).
+ */
 class ServiceAccount
 {
-    /** @var HttpClientInterface */
-    private $apiClient;
-
-    /** @var array<mixed> */
-    private $token;
-
-    /** @var string */
-    private $sandBoxCommunityId;
+    private ?string $sandboxCommunityId;
 
     public function __construct(
-        private ParameterBagInterface $parameters,
+        ParameterBagInterface $parameters,
         private Security $security,
         private MembershipService $membershipService,
+        #[Autowire(service: 'app.api_client.entrepot_sandbox_service_account')]
+        private ApiClient $api,
     ) {
-        // L'id de la community liee au datastore "Bac à sable"
-        $sandbox = $this->parameters->get('sandbox');
-        if ($sandbox && isset($sandbox['community_id'])) {
-            $this->sandBoxCommunityId = $sandbox['community_id'];
-        }
-
-        $this->apiClient = HttpClient::createForBaseUri($this->parameters->get('api_entrepot_url').'/', [
-            'proxy' => $this->parameters->get('http_proxy'),
-            'verify_peer' => false,
-            'verify_host' => false,
-        ]);
-
-        // Recuperation du token du compte de service
-        $this->token = $this->getAccessToken();
+        // id vide dans la config par défaut : bac à sable non configuré
+        $this->sandboxCommunityId = ($parameters->get('sandbox')['community_id'] ?? null) ?: null;
     }
 
     /**
-     * Ajout de l'utilisateur courant (logge) a la communaute liee au datastore "Bac à sable".
+     * Ajoute l'utilisateur connecté à la communauté du bac à sable (no-op s'il en est déjà membre).
+     *
+     * @throws AccessDeniedException bac à sable non configuré, utilisateur absent ou compte de service non authentifié
      */
     public function addCurrentUserToSandbox(): void
     {
-        if (!$this->token) {
-            throw new AccessDeniedException();
+        if (null === $this->sandboxCommunityId) {
+            throw new AccessDeniedException('Bac à sable non configuré');
         }
 
         $user = $this->security->getUser();
@@ -62,101 +46,12 @@ class ServiceAccount
 
         // lecture fraîche : le token peut encore lister une appartenance quittée il y a moins de 60 s sur un autre pod
         $this->membershipService->refreshCurrentUser();
-        if (null !== $user->findMembershipByCommunity($this->sandBoxCommunityId)) {
+        if (null !== $user->findMembershipByCommunity($this->sandboxCommunityId)) {
             return;
         }
 
-        $options = $this->prepareOptions([
+        $this->api->put("communities/{$this->sandboxCommunityId}/users/{$user->getId()}", [
             'rights' => ['ANNEX', 'BROADCAST', 'PROCESSING', 'UPLOAD'],
-        ]);
-
-        $response = $this->apiClient->request('PUT', "communities/{$this->sandBoxCommunityId}/users/{$user->getId()}", $options);
-        $this->handleResponse($response);
-    }
-
-    /**
-     * Recuperation du Token.
-     */
-    private function getAccessToken(): ?array
-    {
-        $uri = $this->parameters->get('iam_url').'/realms/'.$this->parameters->get('iam_realm').'/protocol/openid-connect/';
-
-        $client = HttpClient::createForBaseUri($uri, [
-            'proxy' => $this->parameters->get('http_proxy'),
-            'verify_peer' => false,
-            'verify_host' => false,
-        ]);
-
-        $body = [
-            'grant_type' => 'client_credentials',
-            'client_id' => $this->parameters->get('sandbox_service_account')['client_id'],
-            'client_secret' => $this->parameters->get('sandbox_service_account')['client_secret'],
-        ];
-
-        $response = $client->request('POST', 'token', [
-            'body' => $body,
-            'headers' => [
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept' => 'application/json',
-            ],
-        ]);
-
-        if (Response::HTTP_OK !== $response->getStatusCode()) {
-            return null;
-        }
-
-        return \json_decode($response->getContent(), true);
-    }
-
-    /**
-     * Undocumented function.
-     *
-     * @param array<mixed> $body
-     * @param array<mixed> $query
-     * @param array<mixed> $headers
-     */
-    private function prepareOptions($body = [], $query = [], $headers = []): array
-    {
-        $defaultHeaders = [
-            'Content-Type' => 'application/json',
-        ];
-
-        $options = [
-            'json' => $body,
-            'headers' => array_merge($defaultHeaders, $headers),
-        ];
-
-        $options['headers']['Authorization'] = "Bearer {$this->token['access_token']}";
-        $options['query'] = $query;
-
-        return $options;
-    }
-
-    private function handleResponse(ResponseInterface $response): mixed
-    {
-        $content = null;
-
-        $statusCode = $response->getStatusCode();
-        if ($statusCode >= 200 && $statusCode < 300) { // if request is successful
-            if (204 == $statusCode || '' == $response->getContent()) { // if response body is empty
-                $content = [];
-            } else {
-                $content = $response->toArray();
-            }
-
-            return $content;
-        }
-
-        $errorMsg = 'Entrepot API Error';
-        try {
-            $errorResponse = $response->toArray(false);
-            if (array_key_exists('error_description', $errorResponse)) {
-                $errorMsg = is_array($errorResponse['error_description']) ? implode(', ', $errorResponse['error_description']) : $errorResponse['error_description'];
-            }
-        } catch (JsonException $ex) {
-            $errorResponse = $response->getContent(false);
-        }
-
-        throw new ApiException($errorMsg, $statusCode, $errorResponse);
+        ])->await();
     }
 }

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -3,11 +3,12 @@
 namespace App\Services\EntrepotApi;
 
 use App\ApiClient\ApiClient;
+use App\ApiClient\ServiceAccountAuthenticationException;
 use App\Security\User;
 use App\Services\MembershipService;
+use App\Services\SandboxService;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
@@ -15,17 +16,13 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class ServiceAccount
 {
-    private ?string $sandboxCommunityId;
-
     public function __construct(
-        ParameterBagInterface $parameters,
         private Security $security,
         private MembershipService $membershipService,
+        private SandboxService $sandboxService,
         #[Autowire(service: 'app.api_client.entrepot_sandbox_service_account')]
         private ApiClient $api,
     ) {
-        // id vide dans la config par défaut : bac à sable non configuré
-        $this->sandboxCommunityId = ($parameters->get('sandbox')['community_id'] ?? null) ?: null;
     }
 
     /**
@@ -35,7 +32,8 @@ class ServiceAccount
      */
     public function addCurrentUserToSandbox(): void
     {
-        if (null === $this->sandboxCommunityId) {
+        $sandboxCommunityId = $this->sandboxService->getSandboxCommunityId();
+        if (null === $sandboxCommunityId) {
             throw new AccessDeniedException('Bac à sable non configuré');
         }
 
@@ -46,12 +44,16 @@ class ServiceAccount
 
         // lecture fraîche : le token peut encore lister une appartenance quittée il y a moins de 60 s sur un autre pod
         $this->membershipService->refreshCurrentUser();
-        if (null !== $user->findMembershipByCommunity($this->sandboxCommunityId)) {
+        if (null !== $user->findMembershipByCommunity($sandboxCommunityId)) {
             return;
         }
 
-        $this->api->put("communities/{$this->sandboxCommunityId}/users/{$user->getId()}", [
-            'rights' => ['ANNEX', 'BROADCAST', 'PROCESSING', 'UPLOAD'],
-        ])->await();
+        try {
+            $this->api->put("communities/$sandboxCommunityId/users/{$user->getId()}", [
+                'rights' => ['ANNEX', 'BROADCAST', 'PROCESSING', 'UPLOAD'],
+            ])->await();
+        } catch (ServiceAccountAuthenticationException $e) {
+            throw new AccessDeniedException('Compte de service non authentifié', $e);
+        }
     }
 }

--- a/src/Services/SandboxService.php
+++ b/src/Services/SandboxService.php
@@ -68,10 +68,12 @@ class SandboxService
         }
 
         if (!$this->sandboxDatastoreIdResolved) {
-            $this->sandboxDatastoreId = $this->cache->get("community-{$this->sandboxCommunityId}-datastore-id", function (ItemInterface $item): ?string {
+            $this->sandboxDatastoreId = $this->cache->get("community-{$this->sandboxCommunityId}-datastore-id", function (ItemInterface $item): string {
                 $item->expiresAfter(86400);
 
-                return $this->communityApiService->get($this->sandboxCommunityId)->array()['datastore']['_id'] ?? null;
+                // une communauté sandbox sans datastore est une erreur de configuration : ne pas la mettre en cache
+                return $this->communityApiService->get($this->sandboxCommunityId)->array()['datastore']['_id']
+                    ?? throw new \RuntimeException("La communauté sandbox {$this->sandboxCommunityId} n'a pas de datastore");
             });
             $this->sandboxDatastoreIdResolved = true;
         }

--- a/src/Services/SandboxService.php
+++ b/src/Services/SandboxService.php
@@ -10,75 +10,62 @@ use Symfony\Contracts\Cache\ItemInterface;
 class SandboxService
 {
     private ?string $sandboxCommunityId;
-    private ?string $sandboxDatastoreId;
+    private ?string $sandboxDatastoreId = null;
 
     public function __construct(
         private ParameterBagInterface $parameterBag,
         private CommunityApiService $communityApiService,
         private CacheInterface $cache,
     ) {
-        $this->sandboxDatastoreId = null;
-
-        $sandbox = $this->parameterBag->get('sandbox');
-        $this->sandboxCommunityId = isset($sandbox['community_id']) ? $sandbox['community_id'] : null;
-
-        if ($this->sandboxCommunityId) {
-            // NOTE : on met en cache (24h) le datastore id seulement
-            $key = "community-{$this->sandboxCommunityId}-datastore-id";
-            try {
-                $this->sandboxDatastoreId = $this->cache->get($key, function (ItemInterface $item): string {
-                    $item->expiresAfter(86400);
-
-                    $sandboxCommunity = $this->getSandboxCommunity($this->sandboxCommunityId);
-
-                    return $sandboxCommunity['datastore']['_id'];
-                });
-            } catch (\Throwable $e) {
-            }
-        }
+        // id vide dans la config par défaut : bac à sable non configuré
+        $this->sandboxCommunityId = ($this->parameterBag->get('sandbox')['community_id'] ?? null) ?: null;
     }
 
     public function getProcIntegrateVectorFilesInBase(string $datastoreId): string
     {
-        $apiEntrepot = $this->isSandboxDatastore($datastoreId) ? 'sandbox' : 'api_entrepot';
-        $processings = $this->parameterBag->get($apiEntrepot)['processings'];
-
-        return $processings['int_vect_files_db'];
+        return $this->getProcessings($datastoreId)['int_vect_files_db'];
     }
 
     public function getProcGeneratePyramidVector(string $datastoreId): string
     {
-        $apiEntrepot = $this->isSandboxDatastore($datastoreId) ? 'sandbox' : 'api_entrepot';
-        $processings = $this->parameterBag->get($apiEntrepot)['processings'];
-
-        return $processings['create_vect_pyr'];
+        return $this->getProcessings($datastoreId)['create_vect_pyr'];
     }
 
     public function getProcGeneratePyramidRaster(string $datastoreId): string
     {
-        $apiEntrepot = $this->isSandboxDatastore($datastoreId) ? 'sandbox' : 'api_entrepot';
-        $processings = $this->parameterBag->get($apiEntrepot)['processings'];
-
-        return $processings['create_rast_pyr'];
+        return $this->getProcessings($datastoreId)['create_rast_pyr'];
     }
 
     public function isSandboxDatastore(string $datastoreId): bool
     {
-        return null !== $this->sandboxDatastoreId && $this->sandboxDatastoreId === $datastoreId;
+        $sandboxDatastoreId = $this->getSandboxDatastoreId();
+
+        return null !== $sandboxDatastoreId && $sandboxDatastoreId === $datastoreId;
     }
 
     /**
-     * Récupère la sandbox community. La réponse sera mis dans un cache de 5 mins.
+     * @return array<string,string>
      */
-    private function getSandboxCommunity(string $sandboxCommunityId): array
+    private function getProcessings(string $datastoreId): array
     {
-        return $this->communityApiService->get($sandboxCommunityId)->array();
-        // $key = "community-{$sandboxCommunityId}";
+        $apiEntrepot = $this->isSandboxDatastore($datastoreId) ? 'sandbox' : 'api_entrepot';
 
-        // return $this->cache->get($key, function (ItemInterface $item) use ($sandboxCommunityId) {
-        //     $item->expiresAfter(300);
+        return $this->parameterBag->get($apiEntrepot)['processings'];
+    }
 
-        //     return $this->communityApiService->get($sandboxCommunityId);
-        // });
+    /**
+     * Résolu au premier besoin (pas au constructeur) : la communauté sandbox est la même pour tous, cache serveur 24 h.
+     */
+    private function getSandboxDatastoreId(): ?string
+    {
+        if (null === $this->sandboxCommunityId) {
+            return null;
+        }
+
+        return $this->sandboxDatastoreId ??= $this->cache->get("community-{$this->sandboxCommunityId}-datastore-id", function (ItemInterface $item): ?string {
+            $item->expiresAfter(86400);
+
+            return $this->communityApiService->get($this->sandboxCommunityId)->array()['datastore']['_id'] ?? null;
+        });
     }
 }

--- a/src/Services/SandboxService.php
+++ b/src/Services/SandboxService.php
@@ -11,6 +11,7 @@ class SandboxService
 {
     private ?string $sandboxCommunityId;
     private ?string $sandboxDatastoreId = null;
+    private bool $sandboxDatastoreIdResolved = false;
 
     public function __construct(
         private ParameterBagInterface $parameterBag,
@@ -36,11 +37,15 @@ class SandboxService
         return $this->getProcessings($datastoreId)['create_rast_pyr'];
     }
 
+    /** null si le bac à sable n'est pas configuré */
+    public function getSandboxCommunityId(): ?string
+    {
+        return $this->sandboxCommunityId;
+    }
+
     public function isSandboxDatastore(string $datastoreId): bool
     {
-        $sandboxDatastoreId = $this->getSandboxDatastoreId();
-
-        return null !== $sandboxDatastoreId && $sandboxDatastoreId === $datastoreId;
+        return $this->getSandboxDatastoreId() === $datastoreId;
     }
 
     /**
@@ -54,7 +59,7 @@ class SandboxService
     }
 
     /**
-     * Résolu au premier besoin (pas au constructeur) : la communauté sandbox est la même pour tous, cache serveur 24 h.
+     * Résolu au premier besoin, pas au constructeur : la communauté sandbox est la même pour tous.
      */
     private function getSandboxDatastoreId(): ?string
     {
@@ -62,10 +67,15 @@ class SandboxService
             return null;
         }
 
-        return $this->sandboxDatastoreId ??= $this->cache->get("community-{$this->sandboxCommunityId}-datastore-id", function (ItemInterface $item): ?string {
-            $item->expiresAfter(86400);
+        if (!$this->sandboxDatastoreIdResolved) {
+            $this->sandboxDatastoreId = $this->cache->get("community-{$this->sandboxCommunityId}-datastore-id", function (ItemInterface $item): ?string {
+                $item->expiresAfter(86400);
 
-            return $this->communityApiService->get($this->sandboxCommunityId)->array()['datastore']['_id'] ?? null;
-        });
+                return $this->communityApiService->get($this->sandboxCommunityId)->array()['datastore']['_id'] ?? null;
+            });
+            $this->sandboxDatastoreIdResolved = true;
+        }
+
+        return $this->sandboxDatastoreId;
     }
 }


### PR DESCRIPTION
`ServiceAccount` faisait un appel Keycloak dans son constructeur et portait deux clients HTTP maison avec la vérification TLS désactivée ; `SandboxService` résolvait la communauté sandbox au constructeur en avalant toute erreur.

**Changements**
- `ServiceAccountHttpClient` : décorateur miroir d’`AuthenticatedHttpClient`, token `client_credentials` obtenu au premier appel et mémorisé sur l’instance (pas de cache serveur) ; `ApiClientFactory::createSandboxServiceAccountClient()` et service `app.api_client.entrepot_sandbox_service_account`.
- `ServiceAccount` réduit à sa mission (ajout de l’utilisateur au bac à sable) : plus de `HttpClient::createForBaseUri`, de `prepareOptions` ni de `handleResponse` ; même court-circuit si déjà membre (après lecture fraîche de `users/me`), même `PUT communities/{id}/users/{userId}`.
- Erreur d’authentification du compte de service : `ServiceAccountAuthenticationException` côté `ApiClient`, traduite en 403 par `ServiceAccount`.
- `SandboxService` : résolution de l’id du datastore sandbox au premier besoin (plus au constructeur), toujours derrière le cache serveur 24 h ; suppression du `catch (\Throwable)` silencieux et du code mort ; `getSandboxCommunityId()` est le seul endroit qui normalise la config vide (défaut du `.env`) en « non configuré », `ServiceAccount` le consomme.

**Changements de comportement assumés**
- Vérification TLS active sur les appels du compte de service (le client précédent la désactivait, sans raison consignée depuis 01/2024).
- Les erreurs amont du grant passent par `EntrepotErrorParser` (`ApiException`, statut conservé, message légèrement différent).
- Bac à sable non configuré : 403 explicite au lieu d’un `PUT communities//users/…`.
- Une erreur de résolution du datastore sandbox remonte au lieu de produire un `false` silencieux.

**Validation**
`composer check-rules` ; passe manuelle : quitter puis rejoindre le bac à sable depuis la tuile (grant via le nouveau client, TLS vérifié), dépôt d’une donnée dans le bac à sable.