### PR TITLE
refactor(api): suppression des relectures inutiles dans une même requête (stream C)

### DIFF
--- a/src/Controller/Entrepot/DatasheetController.php
+++ b/src/Controller/Entrepot/DatasheetController.php
@@ -262,7 +262,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             // suppr des uploads
             if (isset($datasheet['upload_list'])) {
                 foreach ($datasheet['upload_list'] as $upload) {
-                    $this->uploadApiService->remove($datastoreId, $upload['_id'])->await();
+                    $this->uploadApiService->remove($datastoreId, $upload['_id'], $upload)->await();
                 }
             }
 

--- a/src/Controller/Entrepot/DatasheetController.php
+++ b/src/Controller/Entrepot/DatasheetController.php
@@ -256,7 +256,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
 
             // suppr des services (config et offering)
             foreach ($servicesList as $offering) {
-                $this->cartesServiceApiService->unpublish($datastoreId, $offering['_id']);
+                $this->cartesServiceApiService->unpublish($datastoreId, $offering['_id'], $offering);
             }
 
             // suppr des uploads

--- a/src/Controller/Entrepot/DatasheetDocumentController.php
+++ b/src/Controller/Entrepot/DatasheetDocumentController.php
@@ -114,7 +114,7 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
             $this->updateListAnnexe($datastoreId, $listAnnexe, $documentsList);
 
             try {
-                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName, $documentsList);
             } catch (\Exception $ex) {
             }
 
@@ -153,7 +153,7 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
             $this->updateListAnnexe($datastoreId, $listAnnexe, $documentsList);
 
             try {
-                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName, $documentsList);
             } catch (\Exception $ex) {
             }
 
@@ -181,6 +181,8 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
                 $document = $tempDocumentsList[0];
             }
 
+            $newDocumentsList = array_values(array_filter($initialDocumentsList, fn ($doc) => $doc['id'] !== $documentId));
+
             if (null !== $document) {
                 switch ($document['type']) {
                     case 'file':
@@ -188,14 +190,11 @@ class DatasheetDocumentController extends AbstractController implements ApiContr
                         break;
                 }
 
-                $newDocumentsList = array_filter($initialDocumentsList, fn ($doc) => $doc['id'] !== $documentId);
-                $newDocumentsList = array_values($newDocumentsList);
-
                 $this->updateListAnnexe($datastoreId, $listAnnexe, $newDocumentsList);
             }
 
             try {
-                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateDocuments($datastoreId, $datasheetName, $newDocumentsList);
             } catch (\Exception $ex) {
             }
 

--- a/src/Controller/Entrepot/MetadataController.php
+++ b/src/Controller/Entrepot/MetadataController.php
@@ -121,8 +121,7 @@ class MetadataController extends AbstractController implements ApiControllerInte
     public function getFileContent(string $datastoreId, string $metadataId, Request $request): Response
     {
         try {
-            $metadata = $this->metadataApiService->get($datastoreId, $metadataId)->array();
-            $xmlFileContent = $this->metadataApiService->downloadFile($datastoreId, $metadata['_id'])->text();
+            $xmlFileContent = $this->metadataApiService->downloadFile($datastoreId, $metadataId)->text();
 
             $format = $request->query->get('format', 'xml');
 

--- a/src/Controller/Entrepot/ServiceController.php
+++ b/src/Controller/Entrepot/ServiceController.php
@@ -109,7 +109,7 @@ class ServiceController extends AbstractController implements ApiControllerInter
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
             $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
 
-            $this->cartesServiceApiService->unpublish($datastoreId, $offeringId);
+            $this->cartesServiceApiService->unpublish($datastoreId, $offeringId, $offering);
 
             // Mise a jour du capabilities
             try {

--- a/src/Controller/Entrepot/StoredDataController.php
+++ b/src/Controller/Entrepot/StoredDataController.php
@@ -133,7 +133,7 @@ class StoredDataController extends AbstractController implements ApiControllerIn
             // récupération de détails sur l'upload s'il y en a un qui a servi à créer la stored_data
             if (isset($storedData['tags']['upload_id'])) {
                 $inputUpload = $this->uploadApiService->get($datastoreId, $storedData['tags']['upload_id'])->array();
-                $inputUpload['file_tree'] = $this->uploadApiService->getFileTree($datastoreId, $inputUpload['_id']);
+                $inputUpload['file_tree'] = $this->uploadApiService->getFileTree($datastoreId, $inputUpload['_id'], $inputUpload);
                 $inputUpload['checks'] = [];
                 $uploadChecks = $this->uploadApiService->getCheckExecutions($datastoreId, $inputUpload['_id'])->array();
 

--- a/src/Controller/Entrepot/UploadController.php
+++ b/src/Controller/Entrepot/UploadController.php
@@ -179,7 +179,7 @@ class UploadController extends AbstractController implements ApiControllerInterf
 
             // supprime livraison si intégration terminée
             if (false === $getOnlyProgress && $uploadIntegrationWorkflow->isIntegrationCompleted($progress)) {
-                $this->uploadApiService->remove($datastoreId, $uploadId)->await();
+                $this->uploadApiService->remove($datastoreId, $uploadId, $upload)->await();
             }
 
             // retourne l'upload complet + tags de progression pour que le frontend ait les données
@@ -216,7 +216,7 @@ class UploadController extends AbstractController implements ApiControllerInterf
         try {
             // Récupération des détails de l'upload ayant échoué
             $inputUpload = $this->uploadApiService->get($datastoreId, $uploadId)->array();
-            $inputUpload['file_tree'] = $this->uploadApiService->getFileTree($datastoreId, $inputUpload['_id']);
+            $inputUpload['file_tree'] = $this->uploadApiService->getFileTree($datastoreId, $inputUpload['_id'], $inputUpload);
             $inputUpload['checks'] = [];
             $uploadChecks = $this->uploadApiService->getCheckExecutions($datastoreId, $inputUpload['_id'])->array();
 

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -290,11 +290,10 @@ class CartesMetadataApiService
         $layers = [];
 
         foreach ($configurationsList as $configuration) {
-            $configurationOfferings = $this->configurationApiService->getConfigurationOfferings($datastoreId, $configuration['_id'])->resolve();
+            $configurationOfferings = $this->configurationApiService->getConfigurationOfferingsDetailed($datastoreId, $configuration['_id'])->resolve();
 
             if (count($configurationOfferings) > 0) {
                 $offering = $configurationOfferings[0];
-                $offering = $this->configurationApiService->getOffering($datastoreId, $offering['_id'])->array();
 
                 $serviceEndpoint = $this->datastoreApiService->getEndpoint($datastoreId, $offering['endpoint']['_id']);
 

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -115,7 +115,10 @@ class CartesMetadataApiService
         $this->metadataApiService->replaceFile($datastoreId, $apiMetadata['_id'], $xmlFilePath);
     }
 
-    public function updateDocuments(string $datastoreId, string $datasheetName): void
+    /**
+     * @param array<mixed> $documents liste de documents de la fiche, déjà en main chez l'appelant
+     */
+    public function updateDocuments(string $datastoreId, string $datasheetName, array $documents): void
     {
         $apiMetadata = $this->getMetadataByDatasheetName($datastoreId, $datasheetName);
         if (!$apiMetadata) {
@@ -125,7 +128,7 @@ class CartesMetadataApiService
         $apiMetadataXml = $this->metadataApiService->downloadFile($datastoreId, $apiMetadata['_id'])->text();
 
         $cswMetadata = $this->cswMetadataHelper->fromXml($apiMetadataXml);
-        $cswMetadata->documents = $this->getDatasheetDocuments($datastoreId, $datasheetName);
+        $cswMetadata->documents = $this->toCswDocuments($documents);
 
         $xmlFilePath = $this->cswMetadataHelper->saveToFile($cswMetadata);
         $this->metadataApiService->replaceFile($datastoreId, $apiMetadata['_id'], $xmlFilePath);
@@ -474,27 +477,17 @@ class CartesMetadataApiService
     }
 
     /**
-     * @return array<CswDocument>
+     * @param array<mixed> $documents
+     *
+     * @return CswDocument[]
      */
-    private function getDatasheetDocuments(string $datastoreId, string $datasheetName): array
+    private function toCswDocuments(array $documents): array
     {
-        $labels = ["datasheet_name=$datasheetName", 'type=document-list'];
-
-        $annexeList = $this->annexeApiService->getAll($datastoreId, null, null, $labels)->resolve();
-
-        // retourne l'annexe s'il existe
-        if (0 === count($annexeList)) {
-            return [];
-        }
-
-        $docsListJson = $this->annexeApiService->download($datastoreId, $annexeList[0]['_id'])->text();
-        $documentsList = json_decode($docsListJson, true);
-
         return array_map(fn ($doc) => new CswDocument(
             $doc['name'],
             isset($doc['description']) ? $doc['description'] : null,
             $doc['url'],
-        ), $documentsList);
+        ), $documents);
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -199,9 +199,12 @@ class CartesServiceApiService
         return $shareUrl;
     }
 
-    public function unpublish(string $datastoreId, string $offeringId): void
+    /**
+     * @param array<mixed>|null $offering offering déjà chargée par l'appelant (avec `type` et `configuration`), évite un GET
+     */
+    public function unpublish(string $datastoreId, string $offeringId, ?array $offering = null): void
     {
-        $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
+        $offering ??= $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
 
         switch ($offering['type']) {
             case OfferingTypes::WFS:

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -513,30 +513,40 @@ class CartesServiceApiService
      */
     private function handlePermissions(string $datastoreId, array $offering, CommonDTO $dto): void
     {
-        // création d'une permission pour la communauté actuelle
-        if ('your_community' === $dto->share_with) {
-            $this->addPermissionForCurrentCommunity($datastoreId, $offering);
+        $shareWithCommunity = 'your_community' === $dto->share_with;
+        $isPrivate = false === $offering['open'];
+        if (!$shareWithCommunity && !$isPrivate) {
+            return;
         }
 
-        if (false === $offering['open']) {
+        // une seule lecture paginée des permissions pour les deux étapes, complétée par les créations
+        $permissions = $this->datastoreApiService->getPermissions($datastoreId)->resolve();
+
+        // création d'une permission pour la communauté actuelle
+        if ($shareWithCommunity) {
+            $communityId = $this->membershipService->getDatastoreIdentity($datastoreId)->communityId;
+            $permissions = [...$permissions, ...$this->addPermissionForCommunity($datastoreId, $communityId, $offering, $permissions)];
+        }
+
+        if ($isPrivate) {
             // création d'une permission pour la communauté config si demandée
             $configCommunityId = $this->params->get('config')['community_id'];
             if ($dto->allow_view_data) {
-                $this->addPermissionForCommunity($datastoreId, $configCommunityId, $offering);
+                $this->addPermissionForCommunity($datastoreId, $configCommunityId, $offering, $permissions);
             } else {
                 // sinon suppression de la permission pour la communauté config si elle existe déjà (elle a été créée lors de la création ou d'une modification précédente de l'offering)
-                $this->removeExistingConfigPermission($datastoreId, $offering);
+                $this->removeExistingConfigPermission($datastoreId, $offering, $permissions);
             }
         }
     }
 
     /**
      * @param array<mixed> $offering
+     * @param array<mixed> $permissions
      */
-    private function removeExistingConfigPermission(string $datastoreId, array $offering): void
+    private function removeExistingConfigPermission(string $datastoreId, array $offering, array $permissions): void
     {
         $configCommunityId = $this->params->get('config')['community_id'];
-        $permissions = $this->datastoreApiService->getPermissions($datastoreId)->resolve();
 
         $existingPermission = array_filter($permissions, function ($permission) use ($offering, $configCommunityId) {
             return isset($permission['offerings'])
@@ -578,20 +588,15 @@ class CartesServiceApiService
     }
 
     /**
+     * Retourne les permissions créées (aucune si elle existait déjà).
+     *
      * @param array<mixed> $offering
+     * @param array<mixed> $permissions permissions existantes du datastore
+     *
+     * @return array<mixed>
      */
-    private function addPermissionForCurrentCommunity(string $datastoreId, array $offering): void
+    private function addPermissionForCommunity(string $producerDatastoreId, string $consumerCommunityId, array $offering, array $permissions): array
     {
-        $communityId = $this->membershipService->getDatastoreIdentity($datastoreId)->communityId;
-        $this->addPermissionForCommunity($datastoreId, $communityId, $offering);
-    }
-
-    /**
-     * @param array<mixed> $offering
-     */
-    private function addPermissionForCommunity(string $producerDatastoreId, string $consumerCommunityId, array $offering): void
-    {
-        $permissions = $this->datastoreApiService->getPermissions($producerDatastoreId)->resolve();
         $offeringId = $offering['_id'];
 
         $offeringPermissions = array_filter($permissions, function ($permission) use ($offeringId) {
@@ -603,7 +608,7 @@ class CartesServiceApiService
         }, false);
 
         if ($permissionExists) {
-            return;
+            return [];
         }
 
         $endDate = new \DateTime();
@@ -619,7 +624,7 @@ class CartesServiceApiService
             'communities' => [$consumerCommunityId],
         ];
 
-        $this->datastoreApiService->addPermission($producerDatastoreId, $permissionRequestBody)->await();
+        return $this->datastoreApiService->addPermission($producerDatastoreId, $permissionRequestBody)->array();
     }
 
     /**

--- a/src/Services/EntrepotApi/ConfigurationApiService.php
+++ b/src/Services/EntrepotApi/ConfigurationApiService.php
@@ -11,6 +11,9 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class ConfigurationApiService
 {
+    // attributs du DTO détaillé d'une offering, identiques dans la liste et le GET unitaire
+    private const OFFERING_DETAIL_FIELDS = 'open,available,layer_name,type,status,endpoint,configuration,urls,creation,extra,update,public_activity';
+
     public function __construct(
         #[Autowire(service: 'app.api_client.entrepot')]
         public readonly ApiClient $api,
@@ -117,6 +120,14 @@ final class ConfigurationApiService
     }
 
     /**
+     * Offerings de la configuration avec tous les attributs du DTO détaillé : pas besoin de GET par offering.
+     */
+    public function getConfigurationOfferingsDetailed(string $datastoreId, string $configurationId): PaginatedPromise
+    {
+        return $this->getConfigurationOfferings($datastoreId, $configurationId, ['fields' => self::OFFERING_DETAIL_FIELDS]);
+    }
+
+    /**
      * @param array<mixed> $query
      */
     public function getOfferingsList(string $datastoreId, array $query = []): PaginatedResponse
@@ -149,7 +160,7 @@ final class ConfigurationApiService
     {
         return $this->getAllOfferings($datastoreId, [
             ...$query,
-            'fields' => 'open,available,layer_name,type,status,endpoint,configuration,urls,creation,extra,update,public_activity', // tous les attributs sont présents, donc pas besoin de GET détaillé pour chaque offering
+            'fields' => self::OFFERING_DETAIL_FIELDS, // tous les attributs sont présents, donc pas besoin de GET détaillé pour chaque offering
         ]);
     }
 

--- a/src/Services/EntrepotApi/UploadApiService.php
+++ b/src/Services/EntrepotApi/UploadApiService.php
@@ -238,11 +238,13 @@ final class UploadApiService
     }
 
     /**
+     * @param array<mixed>|null $upload livraison déjà chargée par l'appelant (avec `status` et `tags`), évite un GET
+     *
      * @return array<mixed>
      */
-    public function getFileTree(string $datastoreId, string $uploadId): array
+    public function getFileTree(string $datastoreId, string $uploadId, ?array $upload = null): array
     {
-        $upload = $this->get($datastoreId, $uploadId)->array();
+        $upload ??= $this->get($datastoreId, $uploadId)->array();
         if (UploadStatuses::DELETED == $upload['status'] || UploadStatuses::OPEN == $upload['status']) {
             if (array_key_exists(UploadTags::FILE_TREE, $upload['tags'])) {
                 return json_decode($upload['tags'][UploadTags::FILE_TREE], true);
@@ -290,11 +292,14 @@ final class UploadApiService
         return $this->api->delete("datastores/$datastoreId/uploads/$uploadId/tags", ['tags' => join(',', $tags)]);
     }
 
-    public function remove(string $datastoreId, string $uploadId): ResponsePromise
+    /**
+     * @param array<mixed>|null $upload livraison déjà chargée par l'appelant (avec `status` et `tags`), évite un GET
+     */
+    public function remove(string $datastoreId, string $uploadId, ?array $upload = null): ResponsePromise
     {
         // sauvegarde dans les tags de l'arborescence de fichiers de la livraison avant de la supprimer, parce qu'une fois supprimée elle ne sera plus récupérable
         try {
-            $fileTree = $this->getFileTree($datastoreId, $uploadId);
+            $fileTree = $this->getFileTree($datastoreId, $uploadId, $upload);
             $this->addTags($datastoreId, $uploadId, [
                 UploadTags::FILE_TREE => json_encode($fileTree),
             ])->await();

--- a/src/Services/EntrepotApi/UserApiService.php
+++ b/src/Services/EntrepotApi/UserApiService.php
@@ -69,9 +69,7 @@ final class UserApiService
      */
     public function updateKey(string $keyId, array $body): array
     {
-        $this->api->patch("users/me/keys/$keyId", $body)->await();
-
-        return $this->getMyKey($keyId)->array();
+        return $this->api->patch("users/me/keys/$keyId", $body)->array();
     }
 
     public function removeKey(string $keyId): ResponsePromise

--- a/src/Services/EntrepotApi/UserApiService.php
+++ b/src/Services/EntrepotApi/UserApiService.php
@@ -65,11 +65,16 @@ final class UserApiService
     }
 
     /**
+     * Relecture volontaire après le PATCH : l'OpenAPI annonce le même DTO que le GET (type_infos requis),
+     * mais la réponse réelle du PATCH omet type_infos, creation et update (constaté le 25/08/2026).
+     *
      * @param array<mixed> $body
      */
     public function updateKey(string $keyId, array $body): array
     {
-        return $this->api->patch("users/me/keys/$keyId", $body)->array();
+        $this->api->patch("users/me/keys/$keyId", $body)->await();
+
+        return $this->getMyKey($keyId)->array();
     }
 
     public function removeKey(string $keyId): ResponsePromise


### PR DESCRIPTION
Plusieurs enchaînements relisaient auprès de l’Entrepôt une ressource que l’appelant venait de charger (offering, livraison, liste de documents, permissions). Chaque item est un commit.

**Changements**
- `CartesServiceApiService::unpublish(..., ?array $offering = null)` : `ServiceController::unpublish` et `DatasheetController::delete` passent l’offering déjà chargée (1 GET de moins par dépublication).
- `MetadataController::getFileContent` télécharge directement le fichier : le `GET metadata` n’était lu que pour `_id`, égal au paramètre de route.
- `UploadApiService::getFileTree` et `remove` acceptent la livraison déjà chargée ; `UploadController` (suivi d’intégration, rapport), `StoredDataController::getReport` et `DatasheetController::delete` la passent.
- `handlePermissions` : une seule lecture paginée des permissions pour les deux étapes (au lieu de deux balayages complets par publication) ; `addPermissionForCommunity` renvoie les permissions créées, ajoutées en mémoire avant l’étape 2 ; aucune lecture quand aucune permission n’est à créer ni supprimer.
- `CartesMetadataApiService::updateDocuments(..., array $documents)` reçoit la liste de documents : les trois mutations de `DatasheetDocumentController` passent celle qu’elles viennent d’écrire (plus de relecture + retéléchargement de l’annexe, `getDatasheetDocuments` supprimé).
- `ConfigurationApiService::getConfigurationOfferingsDetailed()` (champs du DTO détaillé, constante partagée avec `getAllOfferingsDetailed`) : `getMetadataLayers` n’a plus besoin d’un `GET` par offering.

**Changements de comportement assumés**
- Métadonnée : un id inconnu produit toujours un 404, seul le libellé amont peut différer (erreur du téléchargement au lieu du `GET`).

**Non retenu**
- `updateKey` sans relecture après le `PATCH` : l’OpenAPI annonce le même DTO que le `GET` (`type_infos` requis) mais la réponse réelle du `PATCH` omet `type_infos`, `creation` et `update` ; le front alimente son cache avec cette réponse. Relecture conservée, écart documenté dans le code.

**Validation**
`composer check-rules` ; passe faite sur la fiche « Hydrographie des Ardennes » (IGN_Recette) : dépublication d’un service, modification d’une clé, ouverture d’une fiche de métadonnées (xml et json), suivi d’intégration jusqu’au bout, ajout / modification / suppression d’un document, publication WFS partagée avec « votre communauté » et `allow_view_data` activé puis désactivé.
