### PR TITLE
refactor(api): flux lourds sans relectures (métadonnée, suppression de fiche, intégration) (stream D)

### DIFF
--- a/src/Controller/Entrepot/DatasheetController.php
+++ b/src/Controller/Entrepot/DatasheetController.php
@@ -170,11 +170,21 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             'fields' => 'status', // on n'a besoin que de l'_id qui est toujours présent, mais on ne peut pas demander "_id" via "fields", donc "status" parce que c'est un champ léger et qui est toujours présent
         ])->resolve();
 
-        if (0 === count($storedDataList)) {
-            return $this->json([]);
-        }
+        $offeringsById = $this->getOfferingsOfStoredData($datastoreId, $storedDataList);
+        $offeringsById = $this->cartesServiceApiService->getServicesFromOfferings($datastoreId, $offeringsById, false);
 
-        // Déclenche toutes les requêtes de la page 1 en simultané (non bloquant)
+        return $this->json(array_values($offeringsById));
+    }
+
+    /**
+     * Offerings détaillées publiées à partir des stored_data données, listes lancées en parallèle.
+     *
+     * @param array<array<mixed>> $storedDataList
+     *
+     * @return array<string,array<mixed>> clé : offeringId, valeur : offering
+     */
+    private function getOfferingsOfStoredData(string $datastoreId, array $storedDataList): array
+    {
         $pendingAllByStoredData = [];
         foreach ($storedDataList as $storedData) {
             $pendingAllByStoredData[] = $this->configurationApiService->getAllOfferingsDetailed($datastoreId, [
@@ -182,8 +192,6 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             ]);
         }
 
-        // Résolution — les réponses de la page 1 sont déjà en cours
-        /** @var array<mixed> $offeringsById clé : offeringId, valeur : offering */
         $offeringsById = [];
         foreach ($pendingAllByStoredData as $pendingAll) {
             foreach ($pendingAll->resolve() as $offering) {
@@ -191,11 +199,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
             }
         }
 
-        $offeringsById = $this->cartesServiceApiService->getServicesFromOfferings($datastoreId, $offeringsById, false);
-
-        $services = array_values($offeringsById);
-
-        return $this->json($services);
+        return $offeringsById;
     }
 
     /**
@@ -250,48 +254,38 @@ class DatasheetController extends AbstractController implements ApiControllerInt
     public function delete(string $datastoreId, string $datasheetName): Response
     {
         try {
-            $datasheet = json_decode($this->getDetailed($datastoreId, $datasheetName)->getContent(), true);
+            $datasheetTags = ['tags' => [CommonTags::DATASHEET_NAME => $datasheetName]];
+            $pendingUploadList = $this->uploadApiService->getAll($datastoreId, [...$datasheetTags, 'fields' => 'status,tags']);
+            $pendingStoredDataList = $this->storedDataApiService->getAll($datastoreId, [...$datasheetTags, 'fields' => 'type']);
+            $pendingMetadataList = $this->metadataApiService->getAll($datastoreId, $datasheetTags);
 
-            $servicesList = json_decode($this->getServices($datastoreId, $datasheetName)->getContent(), true);
+            $uploadList = $pendingUploadList->resolve();
+            $storedDataList = $pendingStoredDataList->resolve();
+            $metadataList = $pendingMetadataList->resolve();
+
+            if (0 === count($uploadList) && 0 === count($storedDataList) && 0 === count($metadataList)) {
+                throw new CartesApiException("La fiche de donnée [$datasheetName] n'existe pas", Response::HTTP_NOT_FOUND);
+            }
 
             // suppr des services (config et offering)
-            foreach ($servicesList as $offering) {
+            foreach ($this->getOfferingsOfStoredData($datastoreId, $storedDataList) as $offering) {
                 $this->cartesServiceApiService->unpublish($datastoreId, $offering['_id'], $offering);
             }
 
             // suppr des uploads
-            if (isset($datasheet['upload_list'])) {
-                foreach ($datasheet['upload_list'] as $upload) {
-                    $this->uploadApiService->remove($datastoreId, $upload['_id'], $upload)->await();
+            foreach ($uploadList as $upload) {
+                $this->uploadApiService->remove($datastoreId, $upload['_id'], $upload)->await();
+            }
+
+            // suppr des stored_data (bases vecteur et pyramides)
+            $deletableTypes = [StoredDataTypes::VECTOR_DB, StoredDataTypes::ROK4_PYRAMID_VECTOR, StoredDataTypes::ROK4_PYRAMID_RASTER];
+            foreach ($storedDataList as $storedData) {
+                if (in_array($storedData['type'], $deletableTypes, true)) {
+                    $this->cartesStoredDataApiService->delete($datastoreId, $storedData['_id']);
                 }
             }
 
-            // suppr des stored_data
-            $storedDataList = [];
-
-            if (isset($datasheet['vector_db_list'])) {
-                $storedDataList = array_merge($storedDataList, $datasheet['vector_db_list']);
-            }
-
-            if (isset($datasheet['pyramid_vector_list'])) {
-                $storedDataList = array_merge($storedDataList, $datasheet['pyramid_vector_list']);
-            }
-
-            if (isset($datasheet['pyramid_raster_list'])) {
-                $storedDataList = array_merge($storedDataList, $datasheet['pyramid_raster_list']);
-            }
-
-            foreach ($storedDataList as $storedData) {
-                $this->cartesStoredDataApiService->delete($datastoreId, $storedData['_id']);
-            }
-
             // suppr des métadonnées
-            $metadataList = $this->metadataApiService->getAll($datastoreId, [
-                'tags' => [
-                    CommonTags::DATASHEET_NAME => $datasheetName,
-                ],
-            ])->resolve();
-
             if (count($metadataList) > 0) {
                 $metadata = $metadataList[0];
 
@@ -304,6 +298,7 @@ class DatasheetController extends AbstractController implements ApiControllerInt
 
             // TODO : autres données à supprimer
             // Suppression des annexes : vignette, documents associés à la fiche de données etc
+            // listées après la dépublication des services, qui supprime déjà les annexes de style et de capabilities
             $annexes = $this->annexeApiService->getAll($datastoreId, null, null, ["datasheet_name=$datasheetName"])->resolve();
             foreach ($annexes as $annexe) {
                 $this->annexeApiService->remove($datastoreId, $annexe['_id'])->await();

--- a/src/Controller/Entrepot/ServiceController.php
+++ b/src/Controller/Entrepot/ServiceController.php
@@ -107,9 +107,7 @@ class ServiceController extends AbstractController implements ApiControllerInter
             $datastore = $this->datastoreApiService->get($datastoreId);
 
             $offering = $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
-            $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
-
-            $this->cartesServiceApiService->unpublish($datastoreId, $offeringId, $offering);
+            $configuration = $this->cartesServiceApiService->unpublish($datastoreId, $offeringId, $offering);
 
             // Mise a jour du capabilities
             try {

--- a/src/Controller/Entrepot/ServiceController.php
+++ b/src/Controller/Entrepot/ServiceController.php
@@ -126,7 +126,8 @@ class ServiceController extends AbstractController implements ApiControllerInter
             if (isset($configuration['tags'][CommonTags::DATASHEET_NAME])) {
                 $datasheetName = $configuration['tags'][CommonTags::DATASHEET_NAME];
 
-                $this->cartesMetadataApiService->updateLayers($datastoreId, $datasheetName);
+                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateLayers($datastoreId, $datasheetName, $services);
             }
 
             return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -8,6 +8,7 @@ use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
+use App\Services\EntrepotApi\CartesServiceApiService;
 use App\Services\EntrepotApi\CartesStylesApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
 use App\Utils;
@@ -30,6 +31,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
+        private CartesServiceApiService $cartesServiceApiService,
         private CartesStylesApiService $cartesStylesApiService,
     ) {
     }
@@ -79,7 +81,8 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
             try {
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName);
+                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
             } catch (\Throwable) {
                 // ne rien faire si erreur
             }
@@ -152,7 +155,8 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
             try {
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName);
+                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
             } catch (\Throwable) {
                 // ne rien faire si erreur
             }
@@ -213,7 +217,8 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
             try {
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName);
+                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
+                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
             } catch (\Throwable $th) {
                 //  ne rien faire si erreur
             }

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -12,6 +12,7 @@ use App\Services\EntrepotApi\CartesStylesApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
 use App\Utils;
 use OpenApi\Attributes as OA;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,6 +32,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
         private AnnexeApiService $annexeApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
         private CartesStylesApiService $cartesStylesApiService,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -260,7 +262,13 @@ class StyleController extends AbstractController implements ApiControllerInterfa
                 ],
             ]);
             $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $configurations);
-        } catch (\Throwable) {
+        } catch (\Throwable $e) {
+            $this->logger->warning('{class}: Failed to update metadata style files for datasheet {datasheetName}: {error}', [
+                'class' => self::class,
+                'datasheetName' => $datasheetName,
+                'exception' => $e,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/src/Controller/Entrepot/StyleController.php
+++ b/src/Controller/Entrepot/StyleController.php
@@ -8,7 +8,6 @@ use App\Exception\ApiException;
 use App\Exception\CartesApiException;
 use App\Services\EntrepotApi\AnnexeApiService;
 use App\Services\EntrepotApi\CartesMetadataApiService;
-use App\Services\EntrepotApi\CartesServiceApiService;
 use App\Services\EntrepotApi\CartesStylesApiService;
 use App\Services\EntrepotApi\ConfigurationApiService;
 use App\Utils;
@@ -31,7 +30,6 @@ class StyleController extends AbstractController implements ApiControllerInterfa
         private ConfigurationApiService $configurationApiService,
         private AnnexeApiService $annexeApiService,
         private CartesMetadataApiService $cartesMetadataApiService,
-        private CartesServiceApiService $cartesServiceApiService,
         private CartesStylesApiService $cartesStylesApiService,
     ) {
     }
@@ -80,12 +78,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStyles($datastoreId, $configuration['_id'], $styles);
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
-            try {
-                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
-            } catch (\Throwable) {
-                // ne rien faire si erreur
-            }
+            $this->refreshMetadataStyleFiles($datastoreId, $datasheetName);
 
             return new JsonResponse($styles);
         } catch (ApiException $ex) {
@@ -154,12 +147,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStyles($datastoreId, $configuration['_id'], $styles);
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
-            try {
-                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
-            } catch (\Throwable) {
-                // ne rien faire si erreur
-            }
+            $this->refreshMetadataStyleFiles($datastoreId, $datasheetName);
 
             return new JsonResponse($styles);
         } catch (ApiException $ex) {
@@ -216,12 +204,7 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             $this->cartesStylesApiService->updateStyles($datastoreId, $configuration['_id'], $styles);
             $this->cartesStylesApiService->updateStylesTmsMetadata($datastoreId, $configuration, $offeringId, $styles);
 
-            try {
-                $services = $this->cartesServiceApiService->getDatasheetServices($datastoreId, $datasheetName);
-                $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $services);
-            } catch (\Throwable $th) {
-                //  ne rien faire si erreur
-            }
+            $this->refreshMetadataStyleFiles($datastoreId, $datasheetName);
 
             return new JsonResponse($styles);
         } catch (ApiException $ex) {
@@ -262,6 +245,22 @@ class StyleController extends AbstractController implements ApiControllerInterfa
             return new JsonResponse($styles);
         } catch (ApiException $ex) {
             throw new CartesApiException($ex->getMessage(), $ex->getStatusCode(), $ex->getDetails(), $ex);
+        }
+    }
+
+    /**
+     * Met à jour les fichiers de style de la métadonnée ; une erreur ici ne doit pas faire échouer l'opération sur les styles.
+     */
+    private function refreshMetadataStyleFiles(string $datastoreId, string $datasheetName): void
+    {
+        try {
+            $configurations = $this->configurationApiService->getAllDetailed($datastoreId, [
+                'tags' => [
+                    CommonTags::DATASHEET_NAME => $datasheetName,
+                ],
+            ]);
+            $this->cartesMetadataApiService->updateStyleFiles($datastoreId, $datasheetName, $configurations);
+        } catch (\Throwable) {
         }
     }
 

--- a/src/Controller/Entrepot/UploadController.php
+++ b/src/Controller/Entrepot/UploadController.php
@@ -153,9 +153,8 @@ class UploadController extends AbstractController implements ApiControllerInterf
             $upload = $this->uploadApiService->get($datastoreId, $uploadId)->array();
             $progress = $uploadIntegrationWorkflow->computeProgress($datastoreId, $upload);
 
-            if (false === $getOnlyProgress) {
-                $uploadIntegrationWorkflow->advanceIfPossible($datastoreId, $upload, $progress);
-
+            // relecture seulement si une étape a été déclenchée
+            if (false === $getOnlyProgress && $uploadIntegrationWorkflow->advanceIfPossible($datastoreId, $upload, $progress)) {
                 $upload = $this->uploadApiService->get($datastoreId, $uploadId)->array();
                 $progress = $uploadIntegrationWorkflow->computeProgress($datastoreId, $upload);
             }

--- a/src/Dto/Datasheet/DatasheetServices.php
+++ b/src/Dto/Datasheet/DatasheetServices.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Dto\Datasheet;
+
+use App\Constants\EntrepotApi\ConfigurationStatuses;
+
+/**
+ * Configurations (détaillées) et offerings d'une fiche de données, chargées une fois par traitement et passées explicitement.
+ */
+final readonly class DatasheetServices
+{
+    /**
+     * @param array<string,array<mixed>> $configurationsById configuration détaillée par id
+     * @param array<string,array<mixed>> $offeringsById      offering détaillée par id
+     */
+    public function __construct(
+        public array $configurationsById,
+        public array $offeringsById,
+    ) {
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function configurations(): array
+    {
+        return array_values($this->configurationsById);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function configurationsOfType(string ...$types): array
+    {
+        return array_values(array_filter($this->configurationsById, fn (array $configuration) => in_array($configuration['type'], $types, true)));
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function publishedConfigurations(): array
+    {
+        return array_values(array_filter($this->configurationsById, fn (array $configuration) => ConfigurationStatuses::PUBLISHED === $configuration['status']));
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function offeringOfConfiguration(string $configurationId): ?array
+    {
+        foreach ($this->offeringsById as $offering) {
+            if (($offering['configuration']['_id'] ?? null) === $configurationId) {
+                return $offering;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function configurationOfOffering(string $offeringId): ?array
+    {
+        $configurationId = $this->offeringsById[$offeringId]['configuration']['_id'] ?? null;
+
+        return null === $configurationId ? null : ($this->configurationsById[$configurationId] ?? null);
+    }
+}

--- a/src/Dto/Datasheet/DatasheetServices.php
+++ b/src/Dto/Datasheet/DatasheetServices.php
@@ -2,7 +2,7 @@
 
 namespace App\Dto\Datasheet;
 
-use App\Constants\EntrepotApi\ConfigurationStatuses;
+use App\Utils;
 
 /**
  * Configurations (détaillées) et offerings d'une fiche de données, chargées une fois par traitement et passées explicitement.
@@ -20,27 +20,11 @@ final readonly class DatasheetServices
     }
 
     /**
-     * @return array<array<mixed>>
+     * @return array<mixed>|null
      */
-    public function configurations(): array
+    public function offering(string $offeringId): ?array
     {
-        return array_values($this->configurationsById);
-    }
-
-    /**
-     * @return array<array<mixed>>
-     */
-    public function configurationsOfType(string ...$types): array
-    {
-        return array_values(array_filter($this->configurationsById, fn (array $configuration) => in_array($configuration['type'], $types, true)));
-    }
-
-    /**
-     * @return array<array<mixed>>
-     */
-    public function publishedConfigurations(): array
-    {
-        return array_values(array_filter($this->configurationsById, fn (array $configuration) => ConfigurationStatuses::PUBLISHED === $configuration['status']));
+        return $this->offeringsById[$offeringId] ?? null;
     }
 
     /**
@@ -48,13 +32,7 @@ final readonly class DatasheetServices
      */
     public function offeringOfConfiguration(string $configurationId): ?array
     {
-        foreach ($this->offeringsById as $offering) {
-            if (($offering['configuration']['_id'] ?? null) === $configurationId) {
-                return $offering;
-            }
-        }
-
-        return null;
+        return Utils::array_find($this->offeringsById, fn (array $offering) => ($offering['configuration']['_id'] ?? null) === $configurationId);
     }
 
     /**
@@ -62,7 +40,7 @@ final readonly class DatasheetServices
      */
     public function configurationOfOffering(string $offeringId): ?array
     {
-        $configurationId = $this->offeringsById[$offeringId]['configuration']['_id'] ?? null;
+        $configurationId = $this->offering($offeringId)['configuration']['_id'] ?? null;
 
         return null === $configurationId ? null : ($this->configurationsById[$configurationId] ?? null);
     }

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -3,6 +3,7 @@
 namespace App\Services\EntrepotApi;
 
 use App\Constants\EntrepotApi\CommonTags;
+use App\Constants\EntrepotApi\ConfigurationStatuses;
 use App\Constants\EntrepotApi\ConfigurationTypes;
 use App\Constants\EntrepotApi\StoredDataTypes;
 use App\Dto\Datasheet\DatasheetServices;
@@ -86,7 +87,7 @@ class CartesMetadataApiService
 
         $cswMetadata = $this->cswMetadataHelper->fromXml($apiMetadataXml);
         $cswMetadata->layers = $this->getMetadataLayers($datastoreId, $services);
-        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
+        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services->configurationsById);
         $cswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $services);
 
         $xmlFilePath = $this->cswMetadataHelper->saveToFile($cswMetadata);
@@ -98,7 +99,10 @@ class CartesMetadataApiService
         }
     }
 
-    public function updateStyleFiles(string $datastoreId, string $datasheetName, DatasheetServices $services): void
+    /**
+     * @param array<array<mixed>> $configurations configurations détaillées de la fiche
+     */
+    public function updateStyleFiles(string $datastoreId, string $datasheetName, array $configurations): void
     {
         $apiMetadata = $this->getMetadataByDatasheetName($datastoreId, $datasheetName);
         if (!$apiMetadata) {
@@ -108,7 +112,7 @@ class CartesMetadataApiService
         $apiMetadataXml = $this->metadataApiService->downloadFile($datastoreId, $apiMetadata['_id'])->text();
 
         $cswMetadata = $this->cswMetadataHelper->fromXml($apiMetadataXml);
-        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
+        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $configurations);
 
         $xmlFilePath = $this->cswMetadataHelper->saveToFile($cswMetadata);
         $this->metadataApiService->replaceFile($datastoreId, $apiMetadata['_id'], $xmlFilePath);
@@ -266,9 +270,7 @@ class CartesMetadataApiService
             $newCswMetadata->frequencyCode = $formData['frequency_code'] ?? null;
             $newCswMetadata->layers = $layers;
             $newCswMetadata->bbox = $bbox;
-            $newCswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
-
-            // Doit-être calculé après la récupération des layers
+            $newCswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services->configurationsById);
             $newCswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $services);
         }
 
@@ -282,63 +284,64 @@ class CartesMetadataApiService
     {
         $layers = [];
 
-        foreach ($services->configurations() as $configuration) {
+        foreach ($services->configurationsById as $configuration) {
             $offering = $services->offeringOfConfiguration($configuration['_id']);
+            if (null === $offering) {
+                continue;
+            }
 
-            if (null !== $offering) {
-                $serviceEndpoint = $this->datastoreApiService->getEndpoint($datastoreId, $offering['endpoint']['_id']);
+            $serviceEndpoint = $this->datastoreApiService->getEndpoint($datastoreId, $offering['endpoint']['_id']);
 
-                switch ($configuration['type']) {
-                    case ConfigurationTypes::WFS:
-                        $endpointUrl = $serviceEndpoint['endpoint']['urls'][0]['url'];
-                        $subLayers = $this->getWfsSubLayers($configuration, $offering, $endpointUrl);
-                        $layers = array_merge($layers, $subLayers);
+            switch ($configuration['type']) {
+                case ConfigurationTypes::WFS:
+                    $endpointUrl = $serviceEndpoint['endpoint']['urls'][0]['url'];
+                    $subLayers = $this->getWfsSubLayers($configuration, $offering, $endpointUrl);
+                    $layers = array_merge($layers, $subLayers);
 
+                    break;
+
+                case ConfigurationTypes::WMSRASTER:
+                case ConfigurationTypes::WMSVECTOR:
+                    $layerName = $offering['layer_name'];
+                    $gmdOnlineResourceProtocol = 'OGC:WMS';
+                    $endpointUrl = $serviceEndpoint['endpoint']['urls'][0]['url'];
+
+                    $layers[] = new CswMetadataLayer($layerName, $gmdOnlineResourceProtocol, $this->cleanLayerUrl($endpointUrl), $offering['_id'], $offering['open']);
+                    break;
+
+                case ConfigurationTypes::WMTSTMS:
+                    $layerName = $offering['layer_name'];
+
+                    if (!isset($configuration['type_infos']['used_data'][0]['stored_data'])) {
                         break;
+                    }
+                    $pyramid = $this->storedDataApiService->get($datastoreId, $configuration['type_infos']['used_data'][0]['stored_data'])->array();
 
-                    case ConfigurationTypes::WMSRASTER:
-                    case ConfigurationTypes::WMSVECTOR:
-                        $layerName = $offering['layer_name'];
-                        $gmdOnlineResourceProtocol = 'OGC:WMS';
-                        $endpointUrl = $serviceEndpoint['endpoint']['urls'][0]['url'];
+                    $gmdOnlineResourceProtocol = null;
+                    $actualType = null;
 
+                    if (StoredDataTypes::ROK4_PYRAMID_VECTOR === $pyramid['type']) {
+                        $gmdOnlineResourceProtocol = 'TMS';
+                        $actualType = 'TMS';
+                    } elseif (StoredDataTypes::ROK4_PYRAMID_RASTER === $pyramid['type']) {
+                        $gmdOnlineResourceProtocol = 'OGC:WMTS';
+                        $actualType = 'WMTS';
+                    }
+
+                    $endpoints = array_filter($serviceEndpoint['endpoint']['urls'], fn (array $url) => $actualType === $url['type']);
+                    $endpoints = array_values($endpoints);
+
+                    if (count($endpoints) > 0) {
+                        $endpointUrl = $endpoints[0]['url'];
+                        if ('TMS' === $actualType) {
+                            $endpointUrl = $endpointUrl.'/1.0.0';
+                            // la version 1.0.0 du TMS est aussi écrite en dur
+                            // dans le composant UserKeyLink pour créer une URL de 'capabilities'
+                        }
                         $layers[] = new CswMetadataLayer($layerName, $gmdOnlineResourceProtocol, $this->cleanLayerUrl($endpointUrl), $offering['_id'], $offering['open']);
-                        break;
+                    }
 
-                    case ConfigurationTypes::WMTSTMS:
-                        $layerName = $offering['layer_name'];
-
-                        if (!isset($configuration['type_infos']['used_data'][0]['stored_data'])) {
-                            break;
-                        }
-                        $pyramid = $this->storedDataApiService->get($datastoreId, $configuration['type_infos']['used_data'][0]['stored_data'])->array();
-
-                        $gmdOnlineResourceProtocol = null;
-                        $actualType = null;
-
-                        if (StoredDataTypes::ROK4_PYRAMID_VECTOR === $pyramid['type']) {
-                            $gmdOnlineResourceProtocol = 'TMS';
-                            $actualType = 'TMS';
-                        } elseif (StoredDataTypes::ROK4_PYRAMID_RASTER === $pyramid['type']) {
-                            $gmdOnlineResourceProtocol = 'OGC:WMTS';
-                            $actualType = 'WMTS';
-                        }
-
-                        $endpoints = array_filter($serviceEndpoint['endpoint']['urls'], fn (array $url) => $actualType === $url['type']);
-                        $endpoints = array_values($endpoints);
-
-                        if (count($endpoints) > 0) {
-                            $endpointUrl = $endpoints[0]['url'];
-                            if ('TMS' === $actualType) {
-                                $endpointUrl = $endpointUrl.'/1.0.0';
-                                // la version 1.0.0 du TMS est aussi écrite en dur
-                                // dans le composant UserKeyLink pour créer une URL de 'capabilities'
-                            }
-                            $layers[] = new CswMetadataLayer($layerName, $gmdOnlineResourceProtocol, $this->cleanLayerUrl($endpointUrl), $offering['_id'], $offering['open']);
-                        }
-
-                        break;
-                }
+                    break;
             }
         }
 
@@ -376,13 +379,15 @@ class CartesMetadataApiService
     /**
      * Seulement les services WFS et WMTS/WMS sont concernés par les fichiers de style.
      *
+     * @param array<array<mixed>> $configurations configurations détaillées de la fiche
+     *
      * @return array<CswStyleFile>
      */
-    private function getStyleFiles(string $datastoreId, DatasheetServices $services): array
+    private function getStyleFiles(string $datastoreId, array $configurations): array
     {
         $styleFiles = [];
 
-        $configurationsList = $services->configurationsOfType(ConfigurationTypes::WFS, ConfigurationTypes::WMTSTMS);
+        $configurationsList = array_filter($configurations, fn (array $configuration) => in_array($configuration['type'], [ConfigurationTypes::WFS, ConfigurationTypes::WMTSTMS], true));
 
         $configStyles = array_map(fn ($config) => $this->cartesStylesApiService->getStyles($datastoreId, $config), $configurationsList);
         $configStyles = array_filter($configStyles, fn ($stylesList) => count($stylesList) > 0);
@@ -417,7 +422,8 @@ class CartesMetadataApiService
         $datastore = $this->datastoreApiService->get($datastoreId);
         $datastoreName = $datastore['technical_name'];
 
-        $layerTypes = array_map(fn ($config) => $config['type'], $services->publishedConfigurations());
+        $publishedConfigurations = array_filter($services->configurationsById, fn (array $configuration) => ConfigurationStatuses::PUBLISHED === $configuration['status']);
+        $layerTypes = array_map(fn ($config) => $config['type'], $publishedConfigurations);
         $layerTypes = array_values(array_unique($layerTypes));
 
         $annexeUrl = $this->parameterBag->get('annexes_url');

--- a/src/Services/EntrepotApi/CartesMetadataApiService.php
+++ b/src/Services/EntrepotApi/CartesMetadataApiService.php
@@ -3,9 +3,9 @@
 namespace App\Services\EntrepotApi;
 
 use App\Constants\EntrepotApi\CommonTags;
-use App\Constants\EntrepotApi\ConfigurationStatuses;
 use App\Constants\EntrepotApi\ConfigurationTypes;
 use App\Constants\EntrepotApi\StoredDataTypes;
+use App\Dto\Datasheet\DatasheetServices;
 use App\Entity\CswMetadata\CswCapabilitiesFile;
 use App\Entity\CswMetadata\CswDocument;
 use App\Entity\CswMetadata\CswHierarchyLevel;
@@ -32,7 +32,6 @@ class CartesMetadataApiService
         private DatastoreApiService $datastoreApiService,
         private AnnexeApiService $annexeApiService,
         private MetadataApiService $metadataApiService,
-        private ConfigurationApiService $configurationApiService,
         private CswMetadataHelper $cswMetadataHelper,
         private CartesStylesApiService $cartesStylesApiService,
         private StoredDataApiService $storedDataApiService,
@@ -76,7 +75,7 @@ class CartesMetadataApiService
     /**
      * Met à jour la liste des flux si une métadonnée existante fait référence à une fiche de données, sinon fait rien.
      */
-    public function updateLayers(string $datastoreId, string $datasheetName): void
+    public function updateLayers(string $datastoreId, string $datasheetName, DatasheetServices $services): void
     {
         $apiMetadata = $this->getMetadataByDatasheetName($datastoreId, $datasheetName);
         if (!$apiMetadata) {
@@ -86,9 +85,9 @@ class CartesMetadataApiService
         $apiMetadataXml = $this->metadataApiService->downloadFile($datastoreId, $apiMetadata['_id'])->text();
 
         $cswMetadata = $this->cswMetadataHelper->fromXml($apiMetadataXml);
-        $cswMetadata->layers = $this->getMetadataLayers($datastoreId, $datasheetName);
-        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $datasheetName);
-        $cswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $datasheetName);
+        $cswMetadata->layers = $this->getMetadataLayers($datastoreId, $services);
+        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
+        $cswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $services);
 
         $xmlFilePath = $this->cswMetadataHelper->saveToFile($cswMetadata);
         $this->metadataApiService->replaceFile($datastoreId, $apiMetadata['_id'], $xmlFilePath);
@@ -99,7 +98,7 @@ class CartesMetadataApiService
         }
     }
 
-    public function updateStyleFiles(string $datastoreId, string $datasheetName): void
+    public function updateStyleFiles(string $datastoreId, string $datasheetName, DatasheetServices $services): void
     {
         $apiMetadata = $this->getMetadataByDatasheetName($datastoreId, $datasheetName);
         if (!$apiMetadata) {
@@ -109,7 +108,7 @@ class CartesMetadataApiService
         $apiMetadataXml = $this->metadataApiService->downloadFile($datastoreId, $apiMetadata['_id'])->text();
 
         $cswMetadata = $this->cswMetadataHelper->fromXml($apiMetadataXml);
-        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $datasheetName);
+        $cswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
 
         $xmlFilePath = $this->cswMetadataHelper->saveToFile($cswMetadata);
         $this->metadataApiService->replaceFile($datastoreId, $apiMetadata['_id'], $xmlFilePath);
@@ -139,7 +138,7 @@ class CartesMetadataApiService
      *
      * @param array<mixed> $formData
      */
-    public function createOrUpdate(string $datastoreId, string $datasheetName, ?array $formData = null): array
+    public function createOrUpdate(string $datastoreId, string $datasheetName, DatasheetServices $services, ?array $formData = null): array
     {
         $apiMetadata = $this->getMetadataByDatasheetName($datastoreId, $datasheetName);
 
@@ -150,21 +149,21 @@ class CartesMetadataApiService
                 throw new AppException('formData doit être non null si création de la métadonnée', Response::HTTP_INTERNAL_SERVER_ERROR);
             }
 
-            return $this->createMetadata($datastoreId, $datasheetName, $formData);
+            return $this->createMetadata($datastoreId, $datasheetName, $services, $formData);
         }
         // une métadonnée existe déjà qu'on va mettre à jour
 
-        return $this->updateMetadata($datastoreId, $datasheetName, $apiMetadata, $formData);
+        return $this->updateMetadata($datastoreId, $datasheetName, $services, $apiMetadata, $formData);
     }
 
     /**
      * @param array<mixed> $formData
      */
-    private function createMetadata(string $datastoreId, string $datasheetName, array $formData): array
+    private function createMetadata(string $datastoreId, string $datasheetName, DatasheetServices $services, array $formData): array
     {
         $metadataEndpoint = $this->getMetadataEndpoint($datastoreId);
 
-        $newCswMetadata = $this->getNewCswMetadata($datastoreId, $datasheetName, null, $formData);
+        $newCswMetadata = $this->getNewCswMetadata($datastoreId, $datasheetName, $services, null, $formData);
 
         // Ajout de l'etiquette si elle n'existe pas deja
         $thumbnailUrl = $this->getThumbnailUrl($datastoreId, $datasheetName);
@@ -190,14 +189,14 @@ class CartesMetadataApiService
      * @param array<mixed> $oldApiMetadata
      * @param array<mixed> $formData
      */
-    private function updateMetadata(string $datastoreId, string $datasheetName, array $oldApiMetadata, ?array $formData = null): array
+    private function updateMetadata(string $datastoreId, string $datasheetName, DatasheetServices $services, array $oldApiMetadata, ?array $formData = null): array
     {
         $metadataEndpoint = $this->getMetadataEndpoint($datastoreId);
 
         $oldMetadataFileXml = $this->metadataApiService->downloadFile($datastoreId, $oldApiMetadata['_id'])->text();
         $oldCswMetadata = $this->cswMetadataHelper->fromXml($oldMetadataFileXml);
 
-        $newCswMetadata = $this->getNewCswMetadata($datastoreId, $datasheetName, $oldCswMetadata, $formData);
+        $newCswMetadata = $this->getNewCswMetadata($datastoreId, $datasheetName, $services, $oldCswMetadata, $formData);
 
         // Mise a jour de l'etiquette
         $thumbnailUrl = $this->getThumbnailUrl($datastoreId, $datasheetName);
@@ -232,7 +231,7 @@ class CartesMetadataApiService
      *
      * @param ?array<mixed> $formData
      */
-    private function getNewCswMetadata(string $datastoreId, string $datasheetName, ?CswMetadata $oldCswMetadata = null, ?array $formData = null): CswMetadata
+    private function getNewCswMetadata(string $datastoreId, string $datasheetName, DatasheetServices $services, ?CswMetadata $oldCswMetadata = null, ?array $formData = null): CswMetadata
     {
         if (null === $oldCswMetadata && null === $formData) {
             throw new AppException('oldCswMetadata et formData ne peuvent pas être null à la fois', Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -240,7 +239,7 @@ class CartesMetadataApiService
 
         $newCswMetadata = null === $oldCswMetadata ? new CswMetadata() : clone $oldCswMetadata;
 
-        $layers = $this->getMetadataLayers($datastoreId, $datasheetName);
+        $layers = $this->getMetadataLayers($datastoreId, $services);
         $bbox = $this->getBbox($datastoreId, $datasheetName);
 
         if ($formData) {
@@ -267,10 +266,10 @@ class CartesMetadataApiService
             $newCswMetadata->frequencyCode = $formData['frequency_code'] ?? null;
             $newCswMetadata->layers = $layers;
             $newCswMetadata->bbox = $bbox;
-            $newCswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $datasheetName);
+            $newCswMetadata->styleFiles = $this->getStyleFiles($datastoreId, $services);
 
             // Doit-être calculé après la récupération des layers
-            $newCswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $datasheetName);
+            $newCswMetadata->capabilitiesFiles = $this->getCapabilitiesFiles($datastoreId, $services);
         }
 
         return $newCswMetadata;
@@ -279,28 +278,20 @@ class CartesMetadataApiService
     /**
      * @return array<CswMetadataLayer>
      */
-    private function getMetadataLayers(string $datastoreId, string $datasheetName): array
+    private function getMetadataLayers(string $datastoreId, DatasheetServices $services): array
     {
-        $configurationsList = $this->configurationApiService->getAll($datastoreId, [
-            'tags' => [
-                CommonTags::DATASHEET_NAME => $datasheetName,
-            ],
-        ])->resolve();
-
         $layers = [];
 
-        foreach ($configurationsList as $configuration) {
-            $configurationOfferings = $this->configurationApiService->getConfigurationOfferingsDetailed($datastoreId, $configuration['_id'])->resolve();
+        foreach ($services->configurations() as $configuration) {
+            $offering = $services->offeringOfConfiguration($configuration['_id']);
 
-            if (count($configurationOfferings) > 0) {
-                $offering = $configurationOfferings[0];
-
+            if (null !== $offering) {
                 $serviceEndpoint = $this->datastoreApiService->getEndpoint($datastoreId, $offering['endpoint']['_id']);
 
                 switch ($configuration['type']) {
                     case ConfigurationTypes::WFS:
                         $endpointUrl = $serviceEndpoint['endpoint']['urls'][0]['url'];
-                        $subLayers = $this->getWfsSubLayers($datastoreId, $configuration, $offering, $endpointUrl);
+                        $subLayers = $this->getWfsSubLayers($configuration, $offering, $endpointUrl);
                         $layers = array_merge($layers, $subLayers);
 
                         break;
@@ -316,7 +307,6 @@ class CartesMetadataApiService
 
                     case ConfigurationTypes::WMTSTMS:
                         $layerName = $offering['layer_name'];
-                        $configuration = $this->configurationApiService->get($datastoreId, $configuration['_id'])->array();
 
                         if (!isset($configuration['type_infos']['used_data'][0]['stored_data'])) {
                             break;
@@ -356,14 +346,13 @@ class CartesMetadataApiService
     }
 
     /**
-     * @param array<mixed> $configuration
+     * @param array<mixed> $configuration configuration détaillée (type_infos)
      * @param array<mixed> $offering
      *
      * @return array<CswMetadataLayer>
      */
-    private function getWfsSubLayers(string $datastoreId, array $configuration, array $offering, string $serviceEndpointUrl): array
+    private function getWfsSubLayers(array $configuration, array $offering, string $serviceEndpointUrl): array
     {
-        $configuration = $this->configurationApiService->get($datastoreId, $configuration['_id'])->array();
         $configRelations = $configuration['type_infos']['used_data'][0]['relations'];
 
         $relationLayers = array_map(function ($relation) use ($offering, $serviceEndpointUrl) {
@@ -389,25 +378,11 @@ class CartesMetadataApiService
      *
      * @return array<CswStyleFile>
      */
-    private function getStyleFiles(string $datastoreId, string $datasheetName): array
+    private function getStyleFiles(string $datastoreId, DatasheetServices $services): array
     {
         $styleFiles = [];
 
-        $configurationsList = array_merge(
-            [],
-            $this->configurationApiService->getAllDetailed($datastoreId, [
-                'type' => ConfigurationTypes::WFS,
-                'tags' => [
-                    CommonTags::DATASHEET_NAME => $datasheetName,
-                ],
-            ]),
-            $this->configurationApiService->getAllDetailed($datastoreId, [
-                'type' => ConfigurationTypes::WMTSTMS,
-                'tags' => [
-                    CommonTags::DATASHEET_NAME => $datasheetName,
-                ],
-            ])
-        );
+        $configurationsList = $services->configurationsOfType(ConfigurationTypes::WFS, ConfigurationTypes::WMTSTMS);
 
         $configStyles = array_map(fn ($config) => $this->cartesStylesApiService->getStyles($datastoreId, $config), $configurationsList);
         $configStyles = array_filter($configStyles, fn ($stylesList) => count($stylesList) > 0);
@@ -437,18 +412,12 @@ class CartesMetadataApiService
         return $styleFiles;
     }
 
-    private function getCapabilitiesFiles(string $datastoreId, string $datasheetName): array
+    private function getCapabilitiesFiles(string $datastoreId, DatasheetServices $services): array
     {
         $datastore = $this->datastoreApiService->get($datastoreId);
         $datastoreName = $datastore['technical_name'];
 
-        $configurationsList = $this->configurationApiService->getAll($datastoreId, [
-            'tags' => [
-                CommonTags::DATASHEET_NAME => $datasheetName,
-            ],
-            'status' => ConfigurationStatuses::PUBLISHED,
-        ])->resolve();
-        $layerTypes = array_map(fn ($config) => $config['type'], $configurationsList);
+        $layerTypes = array_map(fn ($config) => $config['type'], $services->publishedConfigurations());
         $layerTypes = array_values(array_unique($layerTypes));
 
         $annexeUrl = $this->parameterBag->get('annexes_url');

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -440,8 +440,11 @@ class CartesServiceApiService
         foreach ($siblingServices as $siblingServiceId) {
             try {
                 // les couches de la métadonnée viennent de ces mêmes services : pas de relecture
-                $offering = $services->offeringsById[$siblingServiceId];
+                $offering = $services->offering($siblingServiceId);
                 $configuration = $services->configurationOfOffering($siblingServiceId);
+                if (null === $offering || null === $configuration) {
+                    continue;
+                }
 
                 // Mise à jour des tags seulement si nécessaire
                 if ($configTheme !== ($configuration['tags'][CommonTags::CONFIG_THEME] ?? '')) {

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -401,7 +401,7 @@ class CartesServiceApiService
             ]);
         }
 
-        // Services de la fiche (dont celui qui vient d'être écrit), chargés une fois
+        // Services de la fiche (dont celui qui vient d'être écrit), chargés une fois pour la métadonnée et la synchronisation
         $services = $this->getDatasheetServices($datastoreId, $datasheetName);
 
         // Création ou mise à jour de metadata
@@ -412,7 +412,7 @@ class CartesServiceApiService
         /** @var CswMetadata */
         $cswMetadata = $apiMetadata['csw_metadata'];
 
-        $this->synchroniseSiblingServices($datastoreId, $offering, $configTags[CommonTags::CONFIG_THEME], $cswMetadata, $dto);
+        $this->synchroniseSiblingServices($datastoreId, $offering, $configTags[CommonTags::CONFIG_THEME], $cswMetadata, $dto, $services);
 
         return $offering;
     }
@@ -420,7 +420,7 @@ class CartesServiceApiService
     /**
      * @param array<mixed> $offering
      */
-    private function synchroniseSiblingServices(string $datastoreId, array $offering, string $configTheme, CswMetadata $cswMetadata, CommonDTO $dto): void
+    private function synchroniseSiblingServices(string $datastoreId, array $offering, string $configTheme, CswMetadata $cswMetadata, CommonDTO $dto, DatasheetServices $services): void
     {
         $siblingServices = array_map(fn (CswMetadataLayer $layer) => $layer->offeringId, $cswMetadata->layers ?? []);
         $siblingServices = array_filter($siblingServices, fn (string $serviceId) => $serviceId !== $offering['_id']);
@@ -430,8 +430,9 @@ class CartesServiceApiService
 
         foreach ($siblingServices as $siblingServiceId) {
             try {
-                $offering = $this->configurationApiService->getOffering($datastoreId, $siblingServiceId)->array();
-                $configuration = $this->configurationApiService->get($datastoreId, $offering['configuration']['_id'])->array();
+                // les couches de la métadonnée viennent de ces mêmes services : pas de relecture
+                $offering = $services->offeringsById[$siblingServiceId];
+                $configuration = $services->configurationOfOffering($siblingServiceId);
 
                 // Mise à jour des tags seulement si nécessaire
                 if ($configTheme !== ($configuration['tags'][CommonTags::CONFIG_THEME] ?? '')) {

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -163,13 +163,13 @@ class CartesServiceApiService
             ],
         ]);
 
-        $pendingOfferingsByConfigurationId = [];
+        $pendingOfferingsLists = [];
         foreach ($configurations as $configuration) {
-            $pendingOfferingsByConfigurationId[$configuration['_id']] = $this->configurationApiService->getConfigurationOfferingsDetailed($datastoreId, $configuration['_id']);
+            $pendingOfferingsLists[] = $this->configurationApiService->getConfigurationOfferingsDetailed($datastoreId, $configuration['_id']);
         }
 
         $offeringsById = [];
-        foreach ($pendingOfferingsByConfigurationId as $pendingOfferings) {
+        foreach ($pendingOfferingsLists as $pendingOfferings) {
             foreach ($pendingOfferings->resolve() as $offering) {
                 $offeringsById[$offering['_id']] = $offering;
             }

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -227,9 +227,13 @@ class CartesServiceApiService
     }
 
     /**
+     * Renvoie la configuration supprimée (dernier état lu avant suppression).
+     *
      * @param array<mixed>|null $offering offering déjà chargée par l'appelant (avec `type` et `configuration`), évite un GET
+     *
+     * @return array<mixed>
      */
-    public function unpublish(string $datastoreId, string $offeringId, ?array $offering = null): void
+    public function unpublish(string $datastoreId, string $offeringId, ?array $offering = null): array
     {
         $offering ??= $this->configurationApiService->getOffering($datastoreId, $offeringId)->array();
 
@@ -238,8 +242,7 @@ class CartesServiceApiService
             case OfferingTypes::WMTSTMS:
             case OfferingTypes::WMSVECTOR:
             case OfferingTypes::WMSRASTER:
-                $this->unpublishOfferingAndConfiguration($datastoreId, $offering);
-                break;
+                return $this->unpublishOfferingAndConfiguration($datastoreId, $offering);
             default:
                 throw new CartesApiException('Type de service invalide pour la suppression', Response::HTTP_BAD_REQUEST, ['offering_type' => $offering['type']]);
         }
@@ -247,8 +250,10 @@ class CartesServiceApiService
 
     /**
      * @param array<mixed> $offering
+     *
+     * @return array<mixed> la configuration supprimée
      */
-    private function unpublishOfferingAndConfiguration(string $datastoreId, array $offering, bool $removeStyleFiles = true): void
+    private function unpublishOfferingAndConfiguration(string $datastoreId, array $offering, bool $removeStyleFiles = true): array
     {
         // suppression de l'offering
         $this->configurationApiService->removeOffering($datastoreId, $offering['_id'])->await();
@@ -284,6 +289,8 @@ class CartesServiceApiService
         if (true === $removeStyleFiles) {
             $this->removeStyleFiles($datastoreId, $configuration);
         }
+
+        return $configuration;
     }
 
     /**

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -11,6 +11,7 @@ use App\Constants\EntrepotApi\ConfigurationTypes;
 use App\Constants\EntrepotApi\OfferingTypes;
 use App\Constants\EntrepotApi\PermissionTypes;
 use App\Constants\EntrepotApi\StoredDataTypes;
+use App\Dto\Datasheet\DatasheetServices;
 use App\Dto\Services\CommonDTO;
 use App\Entity\CswMetadata\CswMetadata;
 use App\Entity\CswMetadata\CswMetadataLayer;
@@ -149,6 +150,32 @@ class CartesServiceApiService
         }
 
         return $offeringsById;
+    }
+
+    /**
+     * Configurations détaillées et offerings d'une fiche de données, en une passe (listes d'offerings lancées en parallèle).
+     */
+    public function getDatasheetServices(string $datastoreId, string $datasheetName): DatasheetServices
+    {
+        $configurations = $this->configurationApiService->getAllDetailed($datastoreId, [
+            'tags' => [
+                CommonTags::DATASHEET_NAME => $datasheetName,
+            ],
+        ]);
+
+        $pendingOfferingsByConfigurationId = [];
+        foreach ($configurations as $configuration) {
+            $pendingOfferingsByConfigurationId[$configuration['_id']] = $this->configurationApiService->getConfigurationOfferingsDetailed($datastoreId, $configuration['_id']);
+        }
+
+        $offeringsById = [];
+        foreach ($pendingOfferingsByConfigurationId as $pendingOfferings) {
+            foreach ($pendingOfferings->resolve() as $offering) {
+                $offeringsById[$offering['_id']] = $offering;
+            }
+        }
+
+        return new DatasheetServices(array_column($configurations, null, '_id'), $offeringsById);
     }
 
     /**
@@ -374,9 +401,12 @@ class CartesServiceApiService
             ]);
         }
 
+        // Services de la fiche (dont celui qui vient d'être écrit), chargés une fois
+        $services = $this->getDatasheetServices($datastoreId, $datasheetName);
+
         // Création ou mise à jour de metadata
         $formData = json_decode(json_encode($dto), true);
-        $apiMetadata = $this->cartesMetadataApiService->createOrUpdate($datastoreId, $datasheetName, $formData);
+        $apiMetadata = $this->cartesMetadataApiService->createOrUpdate($datastoreId, $datasheetName, $services, $formData);
 
         // Synchronisation des autres services de la même fiche de données
         /** @var CswMetadata */

--- a/src/Services/EntrepotApi/CartesServiceApiService.php
+++ b/src/Services/EntrepotApi/CartesServiceApiService.php
@@ -258,10 +258,12 @@ class CartesServiceApiService
         // suppression de la configuration
         // la suppression de l'offering nécessite quelques instants, et tant que la suppression de l'offering n'est pas faite, on ne peut pas demander la suppression de la configuration
         for ($attempt = 1; $attempt <= self::UNPUBLISH_MAX_ATTEMPTS; ++$attempt) {
-            sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
             $configuration = $this->configurationApiService->get($datastoreId, $configurationId)->array();
             if (ConfigurationStatuses::UNPUBLISHED === $configuration['status']) {
                 break;
+            }
+            if ($attempt < self::UNPUBLISH_MAX_ATTEMPTS) {
+                sleep(self::UNPUBLISH_RETRY_DELAY_SECONDS);
             }
         }
 

--- a/src/Workflow/UploadIntegrationWorkflow.php
+++ b/src/Workflow/UploadIntegrationWorkflow.php
@@ -78,20 +78,21 @@ class UploadIntegrationWorkflow
 
     /**
      * Exécute au plus une étape à effets de bord (side-effectful), uniquement si c'est l'étape courante et qu'elle est encore en attente.
+     * Renvoie true si une action a été déclenchée (la progression doit alors être recalculée).
      *
      * @param array<mixed>         $upload
      * @param array<string,string> $progress
      */
-    public function advanceIfPossible(string $datastoreId, array $upload, array $progress): void
+    public function advanceIfPossible(string $datastoreId, array $upload, array $progress): bool
     {
         $currentStepName = $this->getCurrentStepName($progress);
         if (null === $currentStepName) {
-            return;
+            return false;
         }
 
         $currentStepStatus = $progress[$currentStepName] ?? JobStatuses::WAITING;
         if (JobStatuses::WAITING !== $currentStepStatus) {
-            return;
+            return false;
         }
 
         switch ($currentStepName) {
@@ -101,18 +102,18 @@ class UploadIntegrationWorkflow
                 }
 
                 if (in_array($upload['status'], [UploadStatuses::CLOSED, UploadStatuses::CHECKING], true)) {
-                    return;
+                    return false;
                 }
 
                 $this->uploadApiService->addFile($datastoreId, $upload['_id'], $upload['tags'][UploadTags::DATA_UPLOAD_PATH]);
 
-                return;
+                return true;
 
             case UploadTags::INT_STEP_PROCESSING:
-                $this->launchIntegrationProcessing($datastoreId, $upload);
-
-                return;
+                return $this->launchIntegrationProcessing($datastoreId, $upload);
         }
+
+        return false;
     }
 
     /**
@@ -253,14 +254,14 @@ class UploadIntegrationWorkflow
     /**
      * @param array<mixed> $upload
      */
-    private function launchIntegrationProcessing(string $datastoreId, array $upload): void
+    private function launchIntegrationProcessing(string $datastoreId, array $upload): bool
     {
         $hasProcExecId = isset($upload['tags']['proc_int_id']);
         $hasVectorDbId = isset($upload['tags']['vectordb_id']);
 
         // ne devrait pas arriver normalement, juste un garde fou
         if ($hasProcExecId || $hasVectorDbId) {
-            return;
+            return false;
         }
 
         if (!isset($upload['tags'][CommonTags::DATASHEET_NAME])) {
@@ -327,6 +328,8 @@ class UploadIntegrationWorkflow
         $this->storedDataApiService->addTags($datastoreId, $vectorDb['_id'], $tags)->await();
 
         $this->processingApiService->launchExecution($datastoreId, $processingExec['_id'])->await();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Suite de #1152 : les flux qui enchaînent beaucoup d’appels à l’Entrepôt (écriture de la métadonnée, suppression d’une fiche, suivi d’intégration, dépublication) relisaient plusieurs fois les mêmes configurations, offerings et livraisons. Chaque item est un commit.

**Changements**
- `DatasheetServices` (objet valeur en lecture seule : configurations détaillées et offerings d’une fiche, par id) chargé une fois par traitement via `CartesServiceApiService::getDatasheetServices()` (1 liste + détails et listes d’offerings en parallèle) et passé explicitement à `CartesMetadataApiService` (`createOrUpdate`, `updateLayers`, `updateStyleFiles`, qui ne dépend plus de `ConfigurationApiService`). Avant : jusqu’à 4 listes de configurations et des `GET` unitaires séquentiels par configuration et par offering à chaque écriture de métadonnée.
- `synchroniseSiblingServices` lit les services voisins dans ce même objet au lieu d’un `GET offering` + `GET configuration` par voisin.
- `DatasheetController::delete` travaille sur des listes résolues une fois (livraisons, données stockées, métadonnées, annexes) au lieu d’appeler ses propres routes `get` et `services` (qui relistaient et enrichissaient pour l’affichage) ; les offerings sont recherchées par une méthode privée partagée avec `getServices`.
- `integration_progress` : `advanceIfPossible` renvoie si une étape a été déclenchée ; la livraison et la progression ne sont relues que dans ce cas (la plupart des sondages ne déclenchent rien : coût divisé par deux).
- Dépublication : le statut de la configuration est lu avant la première attente de 5 s (plus d’attente systématique quand l’offering est déjà supprimée) et `unpublish` renvoie la configuration supprimée, que `ServiceController` n’a plus à relire.

**Mesures** (profileur Symfony, collector `http_client`, même requête `POST .../wfs/{offering}/edit` rejouée à l’identique sur la fiche « _v14_0909 », 6 services dont 4 WFS)

| | `main` (2 rejeux) | cette branche (3 rejeux) |
|---|---|---|
| appels amont par modification de service | 75, 74 | 59, 59, 57 |
| dont lectures (`GET`) | 61 | 45 |
| `GET configurations` (listes) | 4 | 1 |
| `GET configurations/{id}` | 15 | 7 |
| `GET offerings/{id}` | 7 | 1 |

Les écritures (PUT configurations/offerings de la synchronisation des voisins) dépendent de l’état et sont identiques entre les deux versions à état égal. Les durées (7 à 18 s) varient surtout avec la latence amont, pas concluantes sur 5 rejeux.

Autres mesures sur la branche (fiche « Hydrographie des Ardennes », 7 services) : sondage `integration_progress` d’une livraison terminée 7 appels (11 sur `main` par lecture du code : upload, checks, exécution, stored_data relus + 1 `GET upload` dans `getFileTree`) ; dépublication + mise à jour de la métadonnée 35 appels.

**Changements de comportement assumés**
- Sondage d’intégration : une progression amont survenue pendant la requête apparaît au sondage suivant (3 s) au lieu d’être relue immédiatement.
- Dépublication : un `GET configuration` immédiat s’ajoute avant l’attente ; même nombre maximal de tentatives.

**Validation**
`composer check-rules` vert sur chaque commit ; passe faite sur la fiche de test « Hydrographie des Ardennes » (IGN_Recette) : deux modifications d’un WFS avec partage communauté et affichage cartes.gouv.fr activé puis désactivé (permissions, métadonnée, synchronisation des voisins), sondage d’intégration sur une livraison terminée (un seul `GET`, suppression de la livraison), dépublication d’un WFS (13 s, métadonnée mise à jour), puis suppression complète de la fiche (aucune annexe orpheline). La suppression a révélé un ordre incorrect dans une version intermédiaire (annexes listées avant la dépublication des services), corrigé avant commit.
