### PR TITLE
refactor(membership): l’invalidation du snapshot utilisateur suit les mutations d’appartenance dans MembershipService

### DIFF
--- a/src/Controller/Entrepot/CommunityController.php
+++ b/src/Controller/Entrepot/CommunityController.php
@@ -47,9 +47,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
     {
         try {
             $data = json_decode($request->getContent(), true);
-            $community = $this->communityApiService->modifyCommunity($communityId, $data)->array();
-            // le nom de la communauté fait partie des infos dérivées de l'appartenance
-            $this->membershipService->invalidateCurrentUser();
+            $community = $this->membershipService->modifyCommunity($communityId, $data);
 
             return new JsonResponse($community);
         } catch (ApiException $ex) {
@@ -104,11 +102,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
             // Verification des droits
             $this->_checkRights($rights);
 
-            $this->communityApiService->addOrModifyUserRights($communityId, $userId, ['rights' => $rights])->await();
-
-            if ($userId === $user->getId()) {
-                $this->membershipService->invalidateCurrentUser();
-            }
+            $this->membershipService->setMemberRights($communityId, $userId, $rights);
 
             return new JsonResponse([
                 'user' => $userId,
@@ -140,11 +134,7 @@ class CommunityController extends AbstractController implements ApiControllerInt
                 throw new CartesApiException("Vous n'avez pas les droits pour supprimer un membre de cette communauté", JsonResponse::HTTP_BAD_REQUEST);
             }
 
-            $this->communityApiService->removeUserRights($communityId, $userId)->await();
-
-            if ($userId === $user->getId()) {
-                $this->membershipService->invalidateCurrentUser();
-            }
+            $this->membershipService->removeMember($communityId, $userId);
 
             return new JsonResponse(['user' => $userId]);
         } catch (ApiException $ex) {

--- a/src/Controller/Entrepot/UserController.php
+++ b/src/Controller/Entrepot/UserController.php
@@ -212,7 +212,6 @@ class UserController extends AbstractController implements ApiControllerInterfac
     public function addMemberToSandbox(ServiceAccount $serviceAccount): JsonResponse
     {
         $serviceAccount->addCurrentUserToSandbox();
-        $this->membershipService->invalidateCurrentUser();
 
         return new JsonResponse();
     }
@@ -221,8 +220,7 @@ class UserController extends AbstractController implements ApiControllerInterfac
     public function leaveCommunity(string $communityId): JsonResponse
     {
         try {
-            $this->userApiService->leaveCommunity($communityId)->await();
-            $this->membershipService->invalidateCurrentUser();
+            $this->membershipService->leaveCommunity($communityId);
 
             return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
         } catch (ApiException $ex) {

--- a/src/Services/EntrepotApi/CommunityApiService.php
+++ b/src/Services/EntrepotApi/CommunityApiService.php
@@ -26,6 +26,8 @@ final class CommunityApiService
     }
 
     /**
+     * N'invalide pas le snapshot utilisateur : passer par MembershipService, ou appeler MembershipService::invalidateCurrentUser() après coup.
+     *
      * @param array<mixed> $data [name, public, contact]
      */
     public function modifyCommunity(string $communityId, array $data): ResponsePromise
@@ -34,6 +36,8 @@ final class CommunityApiService
     }
 
     /**
+     * N'invalide pas le snapshot utilisateur : passer par MembershipService, ou appeler MembershipService::invalidateCurrentUser() après coup.
+     *
      * @param array<mixed> $rights [community_rights, uploads_rights, processings_rights, stored_data_rights, datastore_rights, broadcast_rights]
      */
     public function addOrModifyUserRights(string $communityId, string $userId, array $rights = []): ResponsePromise
@@ -41,6 +45,9 @@ final class CommunityApiService
         return $this->api->put("communities/$communityId/users/$userId", $rights);
     }
 
+    /**
+     * N'invalide pas le snapshot utilisateur : passer par MembershipService, ou appeler MembershipService::invalidateCurrentUser() après coup.
+     */
     public function removeUserRights(string $communityId, string $userId): ResponsePromise
     {
         return $this->api->delete("communities/$communityId/users/$userId");

--- a/src/Services/EntrepotApi/ServiceAccount.php
+++ b/src/Services/EntrepotApi/ServiceAccount.php
@@ -55,5 +55,7 @@ class ServiceAccount
         } catch (ServiceAccountAuthenticationException $e) {
             throw new AccessDeniedException('Compte de service non authentifié', $e);
         }
+
+        $this->membershipService->invalidateCurrentUser();
     }
 }

--- a/src/Services/EntrepotApi/UserApiService.php
+++ b/src/Services/EntrepotApi/UserApiService.php
@@ -103,6 +103,9 @@ final class UserApiService
         return $this->api->delete("users/me/keys/$keyId/accesses/$accessId");
     }
 
+    /**
+     * N'invalide pas le snapshot utilisateur : passer par MembershipService, ou appeler MembershipService::invalidateCurrentUser() après coup.
+     */
     public function leaveCommunity(string $communityId): ResponsePromise
     {
         return $this->api->delete("users/me/communities/$communityId");

--- a/src/Services/MembershipService.php
+++ b/src/Services/MembershipService.php
@@ -5,11 +5,14 @@ namespace App\Services;
 use App\Dto\Datastore\DatastoreIdentity;
 use App\Security\EntrepotUserCache;
 use App\Security\User;
+use App\Services\EntrepotApi\CommunityApiService;
 use App\Services\EntrepotApi\DatastoreApiService;
+use App\Services\EntrepotApi\UserApiService;
 use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * Dérive les infos datastore/communauté de l'appartenance de l'utilisateur courant, au lieu de charger le DTO datastore complet.
+ * Porte aussi les mutations d'appartenance, pour que l'invalidation du snapshot utilisateur ne puisse pas être oubliée.
  */
 class MembershipService
 {
@@ -17,6 +20,8 @@ class MembershipService
         private Security $security,
         private EntrepotUserCache $entrepotUserCache,
         private DatastoreApiService $datastoreApiService,
+        private UserApiService $userApiService,
+        private CommunityApiService $communityApiService,
     ) {
     }
 
@@ -56,13 +61,49 @@ class MembershipService
         return new DatastoreIdentity($datastore['name'], $datastore['technical_name'], $datastore['community']['_id']);
     }
 
+    public function leaveCommunity(string $communityId): void
+    {
+        $this->userApiService->leaveCommunity($communityId)->await();
+        $this->invalidateCurrentUser();
+    }
+
     /**
-     * À appeler après une mutation d'appartenance faite par l'utilisateur lui-même.
+     * @param array<string> $rights
      */
-    public function invalidateCurrentUser(): void
+    public function setMemberRights(string $communityId, string $userId, array $rights): void
+    {
+        $this->communityApiService->addOrModifyUserRights($communityId, $userId, ['rights' => $rights])->await();
+        $this->invalidateCurrentUser($userId);
+    }
+
+    public function removeMember(string $communityId, string $userId): void
+    {
+        $this->communityApiService->removeUserRights($communityId, $userId)->await();
+        $this->invalidateCurrentUser($userId);
+    }
+
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<mixed> la communauté modifiée
+     */
+    public function modifyCommunity(string $communityId, array $data): array
+    {
+        $community = $this->communityApiService->modifyCommunity($communityId, $data)->array();
+        // le nom de la communauté fait partie des infos dérivées de l'appartenance
+        $this->invalidateCurrentUser();
+
+        return $community;
+    }
+
+    /**
+     * Invalide le snapshot de l'utilisateur courant ; avec $userId, seulement si la mutation le concerne.
+     * Public pour les mutations faites hors de ce service (compte de service).
+     */
+    public function invalidateCurrentUser(?string $userId = null): void
     {
         $user = $this->security->getUser();
-        if ($user instanceof User) {
+        if ($user instanceof User && (null === $userId || $user->getId() === $userId)) {
             $this->entrepotUserCache->invalidate($user->getKeycloakId());
         }
     }


### PR DESCRIPTION
Suite des PR #1150 à #1153. Jusqu’ici, chaque contrôleur devait penser à invalider le snapshot `users/me` après une mutation d’appartenance ; l’oubli est silencieux (données dérivées périmées jusqu’à 60 s). Les mutations passent maintenant par `MembershipService`, qui invalide lui-même.

## Changements

- `MembershipService::leaveCommunity`, `setMemberRights`, `removeMember`, `modifyCommunity` : appel API + invalidation du snapshot ; la garde « l’utilisateur ciblé est l’utilisateur courant » est interne (`invalidateCurrentUser(?string $userId)`).
- `UserController` et `CommunityController` appellent ces méthodes au lieu d’enchaîner appel API + invalidation.
- `ServiceAccount::addCurrentUserToSandbox` invalide après son PUT ; `invalidateCurrentUser()` reste public pour ce seul usage hors service.

Aucun changement de comportement : mêmes appels API, mêmes points d’invalidation.

## Validation

- `composer check-rules` vert.
- Runtime (dev, cache filesystem inspecté directement) : quitter le bac à sable → entrée supprimée ; relecture → snapshot reconstruit sans l’appartenance en un seul `GET users/me` ; rejoindre le bac à sable → entrée supprimée ; relecture → snapshot avec l’appartenance. Aucune erreur dans les logs.
