### PR TITLE
docs: glossaire du projet et cache du snapshot utilisateur par pod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ External API references:
 - Entrepôt docs: https://geoplateforme.github.io/entrepot/production
 - OpenAPI: https://data.geopf.fr/api/v3/api-docs
 
+Project vocabulary (membership, snapshot, grant-path...): `docs/developer/glossaire.md`.
+
 ## Language
 
 - Code identifiers in English (file names, components, props, types, fields), even when the domain vocabulary is French (`producers`, not `producteurs`).

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -3,6 +3,7 @@
 ## Guides généraux
 
 - [Installation et configuration](install.md)
+- [Glossaire](glossaire.md)
 - [Implémentation et exécution des tests](test.md)
 - [Internationalisation](i18n.md)
 - [Explication des workflows](workflows.md)

--- a/docs/developer/auth/README.md
+++ b/docs/developer/auth/README.md
@@ -83,6 +83,28 @@ Navigateur              Symfony
 
 ---
 
+## Snapshot utilisateur Entrepôt et cache par pod
+
+L’objet `User` est reconstruit à chaque requête à partir du JWT et de la réponse `GET users/me` de l’Entrepôt, mise en cache 60 s par identifiant Keycloak ([`EntrepotUserCache`](../../../src/Security/EntrepotUserCache.php), pool `cache.app`). Les infos datastore/communauté (nom, `technical_name`, id de communauté) sont dérivées de ce snapshot par [`MembershipService`](../../../src/Services/MembershipService.php) au lieu d’être rechargées via l’API. Vocabulaire : [glossaire](../glossaire.md).
+
+Trois mécanismes limitent la fenêtre de péremption :
+
+- **Invalidation** après une mutation d’appartenance faite par l’utilisateur lui-même (quitter une communauté, ajout au bac à sable, modification de ses droits ou de sa communauté) : l’entrée est supprimée, la requête suivante recharge.
+- **Rafraîchissement forcé** sur `GET /api/users/me` : la réponse est toujours fraîche et l’entrée du cache est réécrite.
+- **Deny-path** : quand une appartenance n’est pas trouvée, une revalidation forcée est tentée avant de conclure, au plus une fois par 10 s (`fetched_at` stocké dans l’entrée).
+
+En production, `cache.app` est APCu, donc **propre à chaque pod** ; Kubernetes exécute plusieurs réplicas sans affinité de session. Conséquences, acceptées :
+
+| Mécanisme              | Portée          | Effet avec N pods                                                                   |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| Invalidation           | le pod mutateur | les autres pods gardent l’entrée périmée jusqu’à 60 s (seule dégradation)           |
+| Rafraîchissement forcé | le pod servant  | toujours frais quel que soit le pod, et répare le cache de ce pod                   |
+| Deny-path              | le pod servant  | une appartenance manquante est revérifiée sur n’importe quel pod (≤ 1 appel / 10 s) |
+
+Le sens « obtention d’un accès » est donc couvert sur tous les pods. Le sens « retrait d’un accès » ne l’est volontairement pas : seuls des champs dérivés (noms, ids) sont concernés, l’API Entrepôt fait autorité, et une péremption ≤ 60 s existe déjà sur un seul pod. Aucun cache partagé (Redis) n’est prévu pour cela.
+
+---
+
 ## Flux de logout
 
 ```
@@ -149,6 +171,8 @@ Quand `CookieAuthenticator` détecte un token expiré sur une requête `/api/*`,
 | [`src/Security/KeycloakTokenManager.php`](../../../src/Security/KeycloakTokenManager.php)                           | Accès centralisé au token (lecture cookie, cache requête, intent set/clear) |
 | [`src/Security/State/LoginStateSerializer.php`](../../../src/Security/State/LoginStateSerializer.php)               | Encode/décode le paramètre `state` OAuth2 signé HMAC                        |
 | [`src/Security/KeycloakUserProvider.php`](../../../src/Security/KeycloakUserProvider.php)                           | Reconstruit l'objet `User` à partir du JWT (claims Keycloak)                |
+| [`src/Security/EntrepotUserCache.php`](../../../src/Security/EntrepotUserCache.php)                                 | Cache serveur (60 s) de `GET users/me`, invalidation et rafraîchissement    |
+| [`src/Services/MembershipService.php`](../../../src/Services/MembershipService.php)                                 | Dérivation datastore/communauté depuis l'appartenance, deny-path            |
 | [`src/Controller/SecurityController.php`](../../../src/Controller/SecurityController.php)                           | Routes `/login`, `/logout`, `/login/check`                                  |
 | [`src/Listener/LogoutSubscriber.php`](../../../src/Listener/LogoutSubscriber.php)                                   | Récupère l'`id_token` et déclenche la déconnexion SSO Keycloak              |
 | [`src/ApiClient/AuthenticatedHttpClient.php`](../../../src/ApiClient/AuthenticatedHttpClient.php)                   | Injecte `Authorization: Bearer` sur les appels sortants vers l'Entrepôt     |

--- a/docs/developer/glossaire.md
+++ b/docs/developer/glossaire.md
@@ -1,0 +1,21 @@
+# Glossaire
+
+Termes du projet dont le sens n’est pas évident à la lecture du code. Les mécanismes sont décrits dans les documents pointés.
+
+**Appartenance (membership)** : lien entre un utilisateur et une communauté, avec ses droits (`communities_member[]` dans la réponse `GET users/me` de l’Entrepôt). C’est la source unique de la jointure utilisateur ↔ communauté ↔ datastore, côté backend (`MembershipService`, `User::findMembership*`) comme côté frontend (`assets/utils/membership.ts`).
+
+**Dérivation vs autorisation** : les infos datastore/communauté (nom, `technical_name`, id de communauté) sont _dérivées_ de l’appartenance au lieu d’être rechargées via l’API ; ce n’est pas un contrôle d’accès. L’_autorisation_ reste du ressort de l’API Entrepôt, qui refuse elle-même les appels non permis.
+
+**Snapshot utilisateur** : réponse `GET users/me` mise en cache serveur (60 s) par identifiant Keycloak, dont est reconstruit l’objet `User` à chaque requête. Voir [Authentification](./auth/README.md).
+
+**Grant-path** : chemin « l’utilisateur vient d’obtenir un accès » (rejoint une communauté, ajout au bac à sable). Le snapshot doit être invalidé ou rafraîchi pour que la dérivation voie la nouvelle appartenance sans attendre l’expiration du cache.
+
+**Deny-path** : chemin « l’appartenance n’est pas trouvée ». Avant de conclure, une revalidation forcée mais limitée (au plus une par 10 s) du snapshot est tentée : l’appartenance a pu être accordée depuis moins de 60 s.
+
+**Revoke-path** : chemin « l’utilisateur vient de perdre un accès ». Volontairement non traité côté backend : l’API Entrepôt fait autorité et les champs dérivés sont sans risque pendant le délai d’expiration.
+
+**Bac à sable (sandbox)** : communauté de découverte, identifiée par `SANDBOX_COMMUNITY_ID`, que tout utilisateur peut rejoindre en autonomie via le compte de service (`ServiceAccount`). Seul cas de grant self-service de l’application.
+
+**Site MIXED** : appel d’API dont la suppression ne ferait rien gagner, parce que la même requête recharge de toute façon la même ressource par un autre chemin (par exemple un DTO datastore rechargé via `getEndpoint*`). Laissé tel quel, par choix.
+
+**Compte de service** : client Entrepôt authentifié en `client_credentials` (et non avec le token de l’utilisateur), utilisé pour les actions que l’utilisateur ne peut pas faire lui-même, comme s’ajouter au bac à sable.


### PR DESCRIPTION
Documentation qui accompagne les PR #1150 à #1154 (dérivation depuis l’appartenance, cache du snapshot `users/me`).

## Changements

- `docs/developer/glossaire.md` : termes du projet dont le sens n’est pas évident dans le code (appartenance, dérivation vs autorisation, snapshot utilisateur, grant-path / deny-path / revoke-path, bac à sable, site MIXED, compte de service). Termes seulement, les mécanismes restent dans les docs pointées.
- Pointeurs vers le glossaire dans `docs/developer/README.md` et `AGENTS.md`.
- `docs/developer/auth/README.md` : section « Snapshot utilisateur Entrepôt et cache par pod » (construction du `User`, invalidation / rafraîchissement forcé / deny-path, conséquences de l’APCu par pod en production et ce qui est accepté), plus `EntrepotUserCache` et `MembershipService` dans les composants clés.
