### PR TITLE
fix(user): un seul GET users/me amont quand le snapshot vient d’être rechargé

### DIFF
--- a/src/Security/EntrepotUserCache.php
+++ b/src/Security/EntrepotUserCache.php
@@ -5,15 +5,19 @@ namespace App\Security;
 use App\Services\EntrepotApi\UserApiService;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Cache serveur de la réponse GET users/me de l'API Entrepôt, clé par identifiant Keycloak.
  */
-class EntrepotUserCache
+class EntrepotUserCache implements ResetInterface
 {
     private const CACHE_KEY_PREFIX = 'user-me-';
     private const TTL = 60;
     private const REFRESH_THROTTLE = 10;
+
+    /** @var array<string,true> entrées recalculées pendant la requête courante */
+    private array $computedInRequest = [];
 
     public function __construct(
         private UserApiService $userApiService,
@@ -30,13 +34,14 @@ class EntrepotUserCache
     }
 
     /**
-     * Recalcule l'entrée immédiatement, sans la supprimer (garde la protection contre les recalculs concurrents).
+     * Recalcule l'entrée immédiatement, sans la supprimer (garde la protection contre les recalculs concurrents),
+     * sauf si elle vient d'être recalculée pendant cette requête.
      *
      * @return array<mixed>
      */
     public function refresh(string $keycloakId): array
     {
-        return $this->doGet($keycloakId, INF)['data'];
+        return $this->doGet($keycloakId, isset($this->computedInRequest[$keycloakId]) ? null : INF)['data'];
     }
 
     /**
@@ -55,7 +60,13 @@ class EntrepotUserCache
 
     public function invalidate(string $keycloakId): void
     {
+        unset($this->computedInRequest[$keycloakId]);
         $this->cache->delete(self::CACHE_KEY_PREFIX.$keycloakId);
+    }
+
+    public function reset(): void
+    {
+        $this->computedInRequest = [];
     }
 
     /**
@@ -63,9 +74,10 @@ class EntrepotUserCache
      */
     private function doGet(string $keycloakId, ?float $beta = null): array
     {
-        return $this->cache->get(self::CACHE_KEY_PREFIX.$keycloakId, function (ItemInterface $item) {
+        return $this->cache->get(self::CACHE_KEY_PREFIX.$keycloakId, function (ItemInterface $item) use ($keycloakId) {
             $item->expiresAfter(self::TTL);
             $data = $this->userApiService->getMe()->array();
+            $this->computedInRequest[$keycloakId] = true;
 
             return ['fetched_at' => time(), 'data' => $data];
         }, $beta);


### PR DESCRIPTION
`GET /api/users/me` force le rafraîchissement du snapshot `users/me` (fraîcheur garantie sur tous les pods). Mais l’authentification l’a déjà rechargé quelques millisecondes avant quand l’entrée de cache était froide ou expirée : deux appels amont identiques dans la même requête. Même chose dans `ServiceAccount::addCurrentUserToSandbox`.

## Changements

- `EntrepotUserCache` mémorise les entrées recalculées pendant la requête courante ; `refresh()` ne force plus le recalcul dans ce cas (l’entrée est fraîche par construction). `invalidate()` oublie l’entrée, `reset()` (`ResetInterface`, tag `kernel.reset`) vide le mémo entre deux requêtes si le mode worker arrive un jour.
- Aucun changement pour les appelants : `GET /api/users/me` reste toujours frais.

## Validation

`composer check-rules` vert. Runtime (dev, log http_client) : `GET /api/users/me` sur entrée froide = 1 appel amont (2 avant), sur entrée chaude = 1 appel avec `fetched_at` réécrit ; quitter puis rejoindre le bac à sable = 1 `users/me` avant le PUT, entrée invalidée ensuite.
